### PR TITLE
Added publishes conditional messages.

### DIFF
--- a/Component/Asynchronous/src/MessageBus/PublishConditionalMessages.php
+++ b/Component/Asynchronous/src/MessageBus/PublishConditionalMessages.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SimpleBus\Asynchronous\MessageBus;
+
+use SimpleBus\Asynchronous\Publisher\Publisher;
+use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
+
+class PublishConditionalMessages implements MessageBusMiddleware
+{
+
+    /**
+     * @var Publisher
+     */
+    private $publisher;
+    /**
+     * @var callable
+     */
+    private $condition;
+
+    /**
+     * PublishConditionalMessages constructor.
+     * @param Publisher $publisher
+     * @param callable $condition
+     */
+    public function __construct(Publisher $publisher, callable $condition)
+    {
+        $this->publisher = $publisher;
+        $this->condition = $condition;
+    }
+
+    /**
+     * The provided $next callable should be called whenever the next middleware should start handling the message.
+     * Its only argument should be a Message object (usually the same as the originally provided message).
+     *
+     * @param object $message
+     * @param callable $next
+     * @return void
+     */
+    public function handle($message, callable $next)
+    {
+        $callback = $this->condition;
+
+        if ($callback($message)) {
+            $this->publisher->publish($message);
+        }
+
+        $next($message);
+    }
+}

--- a/Component/Asynchronous/tests/MessageBus/PublishConditionalMessagesTest.php
+++ b/Component/Asynchronous/tests/MessageBus/PublishConditionalMessagesTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SimpleBus\Asynchronous\Tests\MessageBus;
+
+use PHPUnit\Framework\TestCase;
+use SimpleBus\Asynchronous\MessageBus\PublishConditionalMessages;
+use SimpleBus\Asynchronous\Publisher\Publisher;
+
+class PublishConditionalMessagesTest extends TestCase
+{
+
+    /**
+     * @param $message
+     * @param $expectedPublish
+     *
+     * @dataProvider queueMessagesDataProvider
+     */
+    public function testPublishesOnlySplQueueMessages($message, $expectedPublish)
+    {
+        $nextCallableCalled = false;
+        $alwaysSucceedingNextCallable = function ($actualMessage) use ($message, &$nextCallableCalled) {
+            $nextCallableCalled = true;
+            $this->assertSame($message, $actualMessage);
+        };
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Publisher $publisher */
+        $publisher = $this->createMock(Publisher::class);
+        $publisher
+            ->expects($expectedPublish ? $this->once() : $this->never())
+            ->method('publish');
+
+        $condition = function ($message) {
+            return $message instanceof \SplQueue;
+        };
+
+        $middleware = new PublishConditionalMessages($publisher, $condition);
+        $middleware->handle($message, $alwaysSucceedingNextCallable);
+
+        $this->assertTrue($nextCallableCalled);
+    }
+
+
+    /**
+     * @param $message
+     * @param $expectedPublish
+     * @dataProvider insideLogicDataProvider
+     */
+    public function testPublishesOnlyAsyncMessages($message, $expectedPublish)
+    {
+        $nextCallableCalled = false;
+        $alwaysSucceedingNextCallable = function ($actualMessage) use ($message, &$nextCallableCalled) {
+            $nextCallableCalled = true;
+            $this->assertSame($message, $actualMessage);
+        };
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Publisher $publisher */
+        $publisher = $this->createMock(Publisher::class);
+        $publisher
+            ->expects($expectedPublish ? $this->once() : $this->never())
+            ->method('publish');
+
+        $condition = function ($message) {
+            /*
+             * Here can be check like
+             *
+             * if ($message instanceof CanBeAsync) {
+             *      return $message->isAsync();
+             * }
+             *
+             * return false;
+             *
+             */
+            if (\is_object($message) && method_exists($message, 'isAsync') && \is_callable([$message, 'isAsync'])) {
+                return $message->isAsync();
+            }
+
+            return false;
+        };
+
+        $middleware = new PublishConditionalMessages($publisher, $condition);
+        $middleware->handle($message, $alwaysSucceedingNextCallable);
+
+        $this->assertTrue($nextCallableCalled);
+    }
+
+    /**
+     * @return array
+     */
+    public function queueMessagesDataProvider(): array
+    {
+        return [
+            [new \SplQueue(), true],
+            [new \stdClass(), false],
+        ];
+    }
+
+    public function insideLogicDataProvider(): array
+    {
+        $async = new class {
+            public function isAsync(): bool
+            {
+                return true;
+            }
+        };
+
+        $notAsync = new class {
+            public function isAsync(): bool
+            {
+                return false;
+            }
+        };
+
+        $another = new \stdClass();
+
+        return [
+            [$async, true],
+            [$notAsync, false],
+            [$another, false],
+        ];
+    }
+}

--- a/docs/Components/Asynchronous.rst
+++ b/docs/Components/Asynchronous.rst
@@ -134,9 +134,10 @@ Strategy 4: Publish messages by a given condition
 
 This strategy is useful when you want to publish messages with different conditions.
 It can be:
-    - Publish `OrderCreatedMessage` only if order amount more than 100 $.
+    - Publish `CompressMessage` only if attachment more than 10 MB.
     - Publish all messages with interface `AsyncMessage`
     - Publish messages with interface `CanBeAsync` (which has method `isAsync`) and if `isAsync` returns `true`
+    - etc.
 
 Let's try to make this scenarios:
 
@@ -155,9 +156,10 @@ Let's try to make this scenarios:
     // $publisher is an instance of Publisher
     $publisher = ...;
 
-    // condition to check order amount
-    $condition = function ($message) {
-        return $message instanceof OrderCreatedMessage && $message->order->amountInDollars() > 100;
+    // condition to check message attachment size
+    $limit = 10;
+    $condition = function ($message) use ($limit) {
+        return $message instanceof CompressMessage && $message->attachment->sizeInMegabytes() >= $limit;
     };
 
     $eventBus->appendMiddleware(new PublishesConditionalMessages($publisher, $condition));

--- a/docs/Components/Asynchronous.rst
+++ b/docs/Components/Asynchronous.rst
@@ -129,6 +129,98 @@ This strategy is useful when you know what messages you want to publish.
 
     $eventBus->handle($event);
 
+Strategy 4: Publish messages by a given condition
+............................................
+
+This strategy is useful when you want to publish messages with different conditions.
+It can be:
+    - Publish `OrderCreatedMessage` only if order amount more than 100 $.
+    - Publish all messages with interface `AsyncMessage`
+    - Publish messages with interface `CanBeAsync` (which has method `isAsync`) and if `isAsync` returns `true`
+
+Let's try to make this scenarios:
+
+1.
+.. code-block::  php
+
+    use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
+    use SimpleBus\Asynchronous\MessageBus\AlwaysPublishesMessages;
+    use SimpleBus\Asynchronous\Publisher\Publisher;
+    use SimpleBus\Message\Message;
+    use SimpleBus\Message\Name\MessageNameResolver;
+
+    // $eventBus is an instance of MessageBusSupportingMiddleware
+    $eventBus = ...;
+
+    // $publisher is an instance of Publisher
+    $publisher = ...;
+
+    // condition to check order amount
+    $condition = function ($message) {
+        return $message instanceof OrderCreatedMessage && $message->order->amountInDollars() > 100;
+    };
+
+    $eventBus->appendMiddleware(new PublishesConditionalMessages($publisher, $condition));
+
+    // $event is an object
+    $event = ...;
+
+    $eventBus->handle($event);
+
+2.
+.. code-block::  php
+
+    use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
+    use SimpleBus\Asynchronous\MessageBus\AlwaysPublishesMessages;
+    use SimpleBus\Asynchronous\Publisher\Publisher;
+    use SimpleBus\Message\Message;
+    use SimpleBus\Message\Name\MessageNameResolver;
+
+    // $eventBus is an instance of MessageBusSupportingMiddleware
+    $eventBus = ...;
+
+    // $publisher is an instance of Publisher
+    $publisher = ...;
+
+    // condition to check `AsyncMessage` interface
+    $condition = function ($message) {
+        return $message instanceof AsyncMessage;
+    };
+
+    $eventBus->appendMiddleware(new PublishesConditionalMessages($publisher, $condition));
+
+    // $event is an object
+    $event = ...;
+
+    $eventBus->handle($event);
+
+3.
+.. code-block::  php
+
+    use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
+    use SimpleBus\Asynchronous\MessageBus\AlwaysPublishesMessages;
+    use SimpleBus\Asynchronous\Publisher\Publisher;
+    use SimpleBus\Message\Message;
+    use SimpleBus\Message\Name\MessageNameResolver;
+
+    // $eventBus is an instance of MessageBusSupportingMiddleware
+    $eventBus = ...;
+
+    // $publisher is an instance of Publisher
+    $publisher = ...;
+
+    // condition to check `isAsync` message
+    $condition = function ($message) {
+        return $message instanceof CanBeAsync && $message->isAsync();
+    };
+
+    $eventBus->appendMiddleware(new PublishesConditionalMessages($publisher, $condition));
+
+    // $event is an object
+    $event = ...;
+
+    $eventBus->handle($event);
+
 Consuming messages
 ------------------
 


### PR DESCRIPTION
The main thing of this PR is publish messages by some condition.

It can be like:
- publish `CompressMessage` if attachment size is more than 10MB.
- publish all messages with interface `AsyncMessage`.
- publish messages with interface `CanBeAsync` (it has method `isAsync`) and if method `isAsync` returns `true`.
- etc. 

It's very simple implementation. Probably you want more orchestrim tool to control that. If it will, it can be something like:

```php

interface PublishMessageCondition
{
   public const PUBLISH_CONDITION_BEFORE = 10;
   public const PUBLISH_CONDITION_AFTER = 20;

   public function supports($message): bool;

   public function when(): int;
}

class PublishConditionChecker 
{
   protected $conditions = [];

  public function addCondition(PublishMessageCondition $condition)
  {
      $this->conditions[] = $condition;
  }

  public function isPublishes($message, int $when)
  {
      foreach ($this->conditions as $condition) {
          if ($condition->when() === $when && $condition->supports($message)) {
              return true;
          }
      }

      return false;
  }
}

class PublishesConditionalMessages implements MessageBusMiddleware
{
   public function __construct(Publisher $publisher, PublishConditionChecker $checker)
   {
       //...
   }

   public function handle($message, callable $next)
   {
       $isPublished = false;
       if ($this->checker->isPublishes($message, PublishMessageCondition::PUBLISH_CONDITION_BEFORE)) {
            $this->publisher->publish($message);
            $isPublished = true;
       }

       $next($message);

       if (false === $isPublished && $this->checker->isPublishes($message, PublishMessageCondition::PUBLISH_CONDITION_AFTER)) {
           $this->publisher->publish($message);
       }
   }
}

```

And usage will be:

```php

class PublishLargeCompressMessages implements  PublishMessageCondition 
{
      private $limit;

      public function __construct($limitInMB)
      {
          $this->limit = $limitInMB;
      }

      public function when(): int
      {
          return PublishMessageCondition::PUBLISH_CONDITION_BEFORE;
      }

      public function supports($message): bool
      {
          return $message instanceof CompressMessage && $message->attachment->sizeInMegabytes() >= $this->limit;
      }
}


$checker = new PublishesConditionChecker();
$checker->add(new PublishLargeCompressMessages(10));

....

$middleware = new PublishesConditionalMessages($publisher, $checker);

...

```

It will allows to control conditions checking before/after `next` calling. But does it need? Or maybe you prefer more concrete middleware like:

```php
class PublishesMessagesWithAsyncInterface implements MessageBusMiddleware
{
   // ...
}
```

?