### PR TITLE
removed deprecation notices on symfony >=4.2

### DIFF
--- a/Bundle/AsynchronousBundle/src/DependencyInjection/Configuration.php
+++ b/Bundle/AsynchronousBundle/src/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder($this->alias);
         $rootNode = $treeBuilder->root($this->alias);
 
         $rootNode

--- a/Bundle/RabbitMQBundleBridge/src/DependencyInjection/Configuration.php
+++ b/Bundle/RabbitMQBundleBridge/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder($this->alias);
 
         $rootNode = $treeBuilder->root($this->alias);
         $rootNode

--- a/Bundle/SymfonyBridge/src/DependencyInjection/CommandBusConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/CommandBusConfiguration.php
@@ -16,7 +16,7 @@ class CommandBusConfiguration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder($this->alias);
 
         $rootNode = $treeBuilder->root($this->alias);
         $rootNode

--- a/Bundle/SymfonyBridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
@@ -16,7 +16,7 @@ class DoctrineOrmBridgeConfiguration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder($this->alias);
 
         $rootNode = $treeBuilder->root($this->alias);
 

--- a/Bundle/SymfonyBridge/src/DependencyInjection/EventBusConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/EventBusConfiguration.php
@@ -16,7 +16,7 @@ class EventBusConfiguration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder($this->alias);
 
         $rootNode = $treeBuilder->root($this->alias);
         $rootNode


### PR DESCRIPTION
Since Symfony 4.2 we have deprecation notices

`A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.`