### PR TITLE
Remove support for Symfony ~2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
       env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
-    - php: 7.2
-      env: SYMFONY_VERSION=2.8.*
     - php: 7.3
       env: SYMFONY_VERSION=3.4.*
     - php: 7.3

--- a/Bridge/JMSSerializerBridge/composer.json
+++ b/Bridge/JMSSerializerBridge/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0",
-        "symfony/yaml": "~2.7 || ~3.3 || ~4.0"
+        "symfony/yaml": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/Bundle/AsynchronousBundle/composer.json
+++ b/Bundle/AsynchronousBundle/composer.json
@@ -28,7 +28,7 @@
         "simple-bus/asynchronous": "~3.0",
         "simple-bus/message-bus": "~3.0",
         "simple-bus/symfony-bridge": "~5.0",
-        "symfony/framework-bundle": "~2.7 || ~3.3 || ~4.0"
+        "symfony/framework-bundle": "~3.3 || ~4.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "~1.2 || ~2.0",

--- a/Bundle/JMSSerializerBundleBridge/composer.json
+++ b/Bundle/JMSSerializerBundleBridge/composer.json
@@ -25,7 +25,7 @@
         "jms/serializer-bundle": "~0.11 || ~1.0 || ~2.0 || ~3.0",
         "simple-bus/asynchronous-bundle": "~3.0",
         "simple-bus/jms-serializer-bridge": "~2.0",
-        "symfony/framework-bundle": "~2.7 || ~3.3 || ~4.0"
+        "symfony/framework-bundle": "~3.3 || ~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0"

--- a/Bundle/RabbitMQBundleBridge/composer.json
+++ b/Bundle/RabbitMQBundleBridge/composer.json
@@ -35,10 +35,10 @@
         "matthiasnoback/phpunit-asynchronicity": "~1.0",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "simple-bus/jms-serializer-bundle-bridge": "~3.0",
-        "symfony/console": "~2.7 || ~3.3 || ~4.0",
-        "symfony/finder": "~2.7 || ~3.3 || ~4.0",
-        "symfony/process": "~2.7 || ~3.3 || ~4.0",
-        "symfony/translation": "~2.7 || ~3.3 || ~4.0"
+        "symfony/console": "~3.3 || ~4.0",
+        "symfony/finder": "~3.3 || ~4.0",
+        "symfony/process": "~3.3 || ~4.0",
+        "symfony/translation": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/Bundle/SymfonyBridge/composer.json
+++ b/Bundle/SymfonyBridge/composer.json
@@ -24,20 +24,20 @@
     "require": {
         "php": "^7.1",
         "simple-bus/message-bus": "~3.0",
-        "symfony/config": "~2.7 || ~3.3 || ~4.0",
-        "symfony/dependency-injection": "~2.7 || ~3.3 || ~4.0",
-        "symfony/http-kernel": "~2.7 || ~3.3 || ~4.0",
-        "symfony/yaml": "~2.7 || ~3.3 || ~4.0"
+        "symfony/config": "~3.3 || ~4.0",
+        "symfony/dependency-injection": "~3.3 || ~4.0",
+        "symfony/http-kernel": "~3.3 || ~4.0",
+        "symfony/yaml": "~3.3 || ~4.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/orm": "~2.5",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "simple-bus/doctrine-orm-bridge": "~5.0",
-        "symfony/framework-bundle": "~2.7 || ~3.3 || ~4.0",
-        "symfony/monolog-bridge": "~2.7 || ~3.3 || ~4.0",
+        "symfony/framework-bundle": "~3.3 || ~4.0",
+        "symfony/monolog-bridge": "~3.3 || ~4.0",
         "symfony/monolog-bundle": "~2.3 || ~3.0",
-        "symfony/proxy-manager-bridge": "~2.7 || ~3.3 || ~4.0"
+        "symfony/proxy-manager-bridge": "~3.3 || ~4.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For integration with Doctrine ORM",

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         "php-amqplib/rabbitmq-bundle": "~1.10",
         "phpunit/phpunit": "^5.7 || ^6.0",
         "psr/log": "~1.0",
-        "symfony/config": "~2.7 || ~3.3 || ~4.0",
-        "symfony/console": "~2.7 || ~3.3 || ~4.0",
-        "symfony/dependency-injection": "~2.7 || ~3.3 || ~4.0",
-        "symfony/finder": "~2.7 || ~3.3 || ~4.0",
-        "symfony/framework-bundle": "~2.7 || ~3.3 || ~4.0",
-        "symfony/http-kernel": "~2.7 || ~3.3 || ~4.0",
+        "symfony/config": "~3.3 || ~4.0",
+        "symfony/console": "~3.3 || ~4.0",
+        "symfony/dependency-injection": "~3.3 || ~4.0",
+        "symfony/finder": "~3.3 || ~4.0",
+        "symfony/framework-bundle": "~3.3 || ~4.0",
+        "symfony/http-kernel": "~3.3 || ~4.0",
         "symfony/monolog-bundle": "~2.3 || ~3.0",
-        "symfony/process": "~2.7 || ~3.3 || ~4.0",
-        "symfony/proxy-manager-bridge": "~2.7 || ~3.3 || ~4.0",
-        "symfony/yaml": "~2.7 || ~3.3 || ~4.0"
+        "symfony/process": "~3.3 || ~4.0",
+        "symfony/proxy-manager-bridge": "~3.3 || ~4.0",
+        "symfony/yaml": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Let's get rid of support for Symfony 2.7 for now. I think it's fine to keep support for 4.0 and 4.1 (even tho they are not supported anymore) as we also support 3.3. 

It will help people upgrade.