### PR TITLE
Use TreeBuilder::getRootNode() instead of TreeBuilder::root() when possible

### DIFF
--- a/Bundle/AsynchronousBundle/src/DependencyInjection/Configuration.php
+++ b/Bundle/AsynchronousBundle/src/DependencyInjection/Configuration.php
@@ -20,7 +20,14 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder($this->alias);
-        $rootNode = $treeBuilder->root($this->alias);
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root($this->alias);
+        }
 
         $rootNode
             ->children()

--- a/Bundle/RabbitMQBundleBridge/src/DependencyInjection/Configuration.php
+++ b/Bundle/RabbitMQBundleBridge/src/DependencyInjection/Configuration.php
@@ -18,7 +18,14 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder($this->alias);
 
-        $rootNode = $treeBuilder->root($this->alias);
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root($this->alias);
+        }
+
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()

--- a/Bundle/SymfonyBridge/src/DependencyInjection/CommandBusConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/CommandBusConfiguration.php
@@ -18,7 +18,14 @@ class CommandBusConfiguration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder($this->alias);
 
-        $rootNode = $treeBuilder->root($this->alias);
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root($this->alias);
+        }
+
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()

--- a/Bundle/SymfonyBridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
@@ -18,7 +18,13 @@ class DoctrineOrmBridgeConfiguration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder($this->alias);
 
-        $rootNode = $treeBuilder->root($this->alias);
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root($this->alias);
+        }
 
         $rootNode
             ->addDefaultsIfNotSet()

--- a/Bundle/SymfonyBridge/src/DependencyInjection/EventBusConfiguration.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/EventBusConfiguration.php
@@ -18,7 +18,14 @@ class EventBusConfiguration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder($this->alias);
 
-        $rootNode = $treeBuilder->root($this->alias);
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            // Symfony 4.2 +
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // Symfony 4.1 and below
+            $rootNode = $treeBuilder->root($this->alias);
+        }
+
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()


### PR DESCRIPTION
Because https://symfony.com/blog/new-in-symfony-4-2-important-deprecations 

By taking example on https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/594/files