### PR TITLE
Feature > Output class in exception when AutoRegister fails

### DIFF
--- a/Bundle/SymfonyBridge/src/DependencyInjection/Compiler/AutoRegister.php
+++ b/Bundle/SymfonyBridge/src/DependencyInjection/Compiler/AutoRegister.php
@@ -2,6 +2,7 @@
 
 namespace SimpleBus\SymfonyBridge\DependencyInjection\Compiler;
 
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -56,6 +57,11 @@ final class AutoRegister implements CompilerPassInterface
                     // if no param or optional param, skip
                     if (count($parameters) !== 1 || $parameters[0]->isOptional()) {
                         continue;
+                    }
+
+                    if ($parameters[0]->getClass() === null) {
+                        throw new RuntimeException(sprintf('Could not get auto register class %s because the first parameter %s of public method %s should be have a class typehint. Either specify the typehint, make the function non-public, or disable auto registration.', $method->class,
+                            $parameters[0]->getName(), $method->getName()));
                     }
 
                     // get the class name


### PR DESCRIPTION
When a public class that is wrongly configured or misplaced fails, it's hard to debug. This is because it will fail on a `getName()` function call on a `null` object. 

As I was debugging this issue I thought it would be nice to output the class name it fails on and improve the developer experience.

To reproduce, place a class that has public methods in a directory auto-wired as an `event_subscriber`. It will throw an exception with the class instead of a null pointer exception. 

I'm not that familiar with the rest of the SimpleBus architecture so if something is missing please let me know and I will fix it. 