### PR TITLE
Catch Throwable insteadof Exception

### DIFF
--- a/Component/MessageBus/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
+++ b/Component/MessageBus/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Bus\Middleware;
 
-use Exception;
+use Throwable;
 
 class FinishesHandlingMessageBeforeHandlingNext implements MessageBusMiddleware
 {
@@ -32,7 +32,7 @@ class FinishesHandlingMessageBeforeHandlingNext implements MessageBusMiddleware
             while ($message = array_shift($this->queue)) {
                 try {
                     $next($message);
-                } catch (Exception $exception) {
+                } catch (Throwable $exception) {
                     $this->isHandling = false;
 
                     throw $exception;

--- a/Component/MessageBus/tests/Bus/FinishesCommandBeforeHandlingNextTest.php
+++ b/Component/MessageBus/tests/Bus/FinishesCommandBeforeHandlingNextTest.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Tests\Message;
 
-use Exception;
+use Throwable;
 use PHPUnit\Framework\TestCase;
 use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
 use SimpleBus\Message\Bus\Middleware\FinishesHandlingMessageBeforeHandlingNext;
@@ -59,7 +59,7 @@ class FinishesMessageBeforeHandlingNextTest extends TestCase
         $message1 = $this->dummyMessage();
         $message2 = $this->dummyMessage();
         $handledMessages = [];
-        $exceptionForMessage1 = new Exception();
+        $exceptionForMessage1 = new \TypeError();
 
         $messageBus = new MessageBusSupportingMiddleware();
         $messageBus->appendMiddleware(new FinishesHandlingMessageBeforeHandlingNext());
@@ -80,7 +80,7 @@ class FinishesMessageBeforeHandlingNextTest extends TestCase
         try {
             $messageBus->handle($message1);
             $this->fail('An exception should have been thrown');
-        } catch (Exception $actualException) {
+        } catch (Throwable $actualException) {
             $this->assertSame($exceptionForMessage1, $actualException);
         }
 


### PR DESCRIPTION
This should be fixed when `"php": "^7.1",` was added to composer.json
This fix is worth describing in the issue, which I will do soon :wink: 
