### PR TITLE
Test Symfony 4.4 instead of 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     - php: 7.3
       env: SYMFONY_VERSION=3.4.*
     - php: 7.3
-      env: SYMFONY_VERSION=4.2.*
+      env: SYMFONY_VERSION=4.4.*
     - php: 7.3
-      env: SYMFONY_VERSION=4.2.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
+      env: SYMFONY_VERSION=4.4.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
   allow_failures:
     - env: COMPOSER_FLAGS="--prefer-lowest"
 


### PR DESCRIPTION
Let's make our life a bit easier and just test:

* Symfony 3.4 LTS
* Symfony 4.4 LTS