### PR TITLE
Support Symfony 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /phpunit.xml
 /split/git-subsplit
 /split/.subsplit
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,23 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
     - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
     - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.3
       env: SYMFONY_VERSION=4.4.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
 
 env:
   global:
@@ -36,12 +43,14 @@ env:
     - SYMFONY_VERSION=""
 
 before_install:
-  - composer self-update
+  - composer self-update -q
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/config:$SYMFONY_VERSION symfony/console:$SYMFONY_VERSION symfony/dependency-injection:$SYMFONY_VERSION symfony/finder:$SYMFONY_VERSION symfony/framework-bundle:$SYMFONY_VERSION symfony/http-kernel:$SYMFONY_VERSION symfony/monolog-bridge:$SYMFONY_VERSION symfony/process:$SYMFONY_VERSION symfony/proxy-manager-bridge:$SYMFONY_VERSION symfony/yaml:$SYMFONY_VERSION symfony/routing:$SYMFONY_VERSION ; fi
 
 install:
-  - composer update --prefer-dist $COMPOSER_FLAGS
+  - composer update --no-interaction --prefer-dist $COMPOSER_FLAGS
   - if [ "$REMOVE_PROXY_BRIDGE" == "yes" ]; then composer remove symfony/proxy-manager-bridge; fi
+  - composer show
 
 script:
   - ./vendor/bin/phpunit $EXTRA_PHPUNIT_PARAMS

--- a/Bridge/DoctrineDBALBridge/.travis.yml
+++ b/Bridge/DoctrineDBALBridge/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
   global:

--- a/Bridge/DoctrineDBALBridge/composer.json
+++ b/Bridge/DoctrineDBALBridge/composer.json
@@ -22,11 +22,11 @@
     ],
     "require": {
         "php": "^7.3",
-        "doctrine/dbal": "~2.5",
-        "simple-bus/message-bus": "~3.0"
+        "doctrine/dbal": "^2.5",
+        "simple-bus/message-bus": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/Bridge/DoctrineORMBridge/.travis.yml
+++ b/Bridge/DoctrineORMBridge/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
   global:

--- a/Bridge/DoctrineORMBridge/composer.json
+++ b/Bridge/DoctrineORMBridge/composer.json
@@ -26,12 +26,12 @@
     ],
     "require": {
         "php": "^7.3",
-        "doctrine/orm": "~2.5",
-        "simple-bus/message-bus": "~3.0"
+        "doctrine/orm": "^2.7",
+        "simple-bus/message-bus": "^3.0"
     },
     "require-dev": {
-        "matthiasnoback/doctrine-orm-test-service-provider": "~3.0",
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "matthiasnoback/doctrine-orm-test-service-provider": "^3.0",
+        "phpunit/phpunit": "^8.2.3"
     },
     "suggest": {
         "simple-bus/symfony-bridge": "Bridge for using command buses and event buses with Symfony"

--- a/Bridge/DoctrineORMBridge/tests/EventListener/CollectsEventsFromEntitiesTest.php
+++ b/Bridge/DoctrineORMBridge/tests/EventListener/CollectsEventsFromEntitiesTest.php
@@ -28,7 +28,7 @@ class CollectsEventsFromEntitiesTest extends TestCase
         return array(__DIR__.'/Fixtures/Entity');
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class CollectsEventsFromEntitiesTest extends TestCase
         $entity = new EventRecordingEntity();
 
         $this->persistAndFlush($entity);
-        $this->assertContains( new EntityCreated(), $this->eventSubscriber->recordedMessages(), '', false, false );
+        $this->assertContainsEquals(new EntityCreated(), $this->eventSubscriber->recordedMessages());
 
         $this->assertEntityHasNoRecordedEvents($entity);
     }
@@ -61,7 +61,7 @@ class CollectsEventsFromEntitiesTest extends TestCase
         $entity->changeSomething();
         $this->persistAndFlush($entity);
 
-        $this->assertContains( new EntityChanged(), $this->eventSubscriber->recordedMessages(), '', false, false );
+        $this->assertContainsEquals(new EntityChanged(), $this->eventSubscriber->recordedMessages());
 
         $this->assertEntityHasNoRecordedEvents($entity);
     }
@@ -108,7 +108,7 @@ class CollectsEventsFromEntitiesTest extends TestCase
         $entity = new EventRecordingEntity();
         $this->persistAndFlush($entity);
 
-        $this->assertContains( new EntityCreatedPrePersist(), $this->eventSubscriber->recordedMessages(), '', false, false );
+        $this->assertContainsEquals(new EntityCreatedPrePersist(), $this->eventSubscriber->recordedMessages());
 
         $this->assertEntityHasNoRecordedEvents($entity);
     }

--- a/Bridge/JMSSerializerBridge/.travis.yml
+++ b/Bridge/JMSSerializerBridge/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
   global:

--- a/Bridge/JMSSerializerBridge/composer.json
+++ b/Bridge/JMSSerializerBridge/composer.json
@@ -26,12 +26,12 @@
     ],
     "require": {
         "php": "^7.3",
-        "jms/serializer": "~0.12 || ~1.0 || ~2.0 || ~3.0",
-        "simple-bus/serialization": "~3.0"
+        "jms/serializer": "^2.0 || ^3.0",
+        "simple-bus/serialization": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0",
-        "symfony/yaml": "~3.3 || ~4.0"
+        "phpunit/phpunit": "^8.5",
+        "symfony/yaml": "^4.4 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/Bundle/AsynchronousBundle/.travis.yml
+++ b/Bundle/AsynchronousBundle/.travis.yml
@@ -12,14 +12,19 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
     - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
 
 env:
   global:

--- a/Bundle/AsynchronousBundle/composer.json
+++ b/Bundle/AsynchronousBundle/composer.json
@@ -28,16 +28,16 @@
     ],
     "require": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0",
-        "simple-bus/asynchronous": "~3.0",
-        "simple-bus/message-bus": "~3.0",
-        "simple-bus/symfony-bridge": "~5.0",
-        "symfony/framework-bundle": "~3.3 || ~4.0"
+        "beberlei/assert": "^3.0",
+        "simple-bus/asynchronous": "^3.0",
+        "simple-bus/message-bus": "^3.0",
+        "simple-bus/symfony-bridge": "^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "~1.2 || ~2.0",
-        "phpunit/phpunit": "^5.7 || ^6.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "phpunit/phpunit": "^8.5",
+        "symfony/monolog-bundle": "^3.4"
     },
     "suggest": {
         "symfony/monolog-bundle": "For logging messages"

--- a/Bundle/AsynchronousBundle/tests/Functional/SimpleBusAsynchronousBundleTest.php
+++ b/Bundle/AsynchronousBundle/tests/Functional/SimpleBusAsynchronousBundleTest.php
@@ -13,7 +13,7 @@ class SimpleBusAsynchronousBundleTest extends KernelTestCase
         return 'SimpleBus\AsynchronousBundle\Tests\Functional\TestKernel';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Bundle/AsynchronousBundle/tests/Unit/DepencencyInjection/Compiler/CollectAsynchronousEventNamesTest.php
+++ b/Bundle/AsynchronousBundle/tests/Unit/DepencencyInjection/Compiler/CollectAsynchronousEventNamesTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class CollectAsynchronousEventNamesTest extends AbstractCompilerPassTestCase
 {
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container) : void
     {
         $container->addCompilerPass(new CollectAsynchronousEventNames());
     }

--- a/Bundle/AsynchronousBundle/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
+++ b/Bundle/AsynchronousBundle/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
@@ -3,19 +3,21 @@
 namespace SimpleBus\AsynchronousBundle\Tests\Unit\DependencyInjection;
 
 
+use LogicException;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use SimpleBus\AsynchronousBundle\DependencyInjection\SimpleBusAsynchronousExtension;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions() : array
     {
         return array(
             new SimpleBusAsynchronousExtension('simple_bus_asynchronous')
         );
     }
 
-    protected function getMinimalConfiguration()
+    protected function getMinimalConfiguration() : array
     {
         return ['object_serializer_service_id'=>'my_serializer', 'commands'=>['publisher_service_id'=>'pusher'], 'events'=>['publisher_service_id'=>'pusher']];
     }
@@ -45,33 +47,36 @@ class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessageRegExp ".*custom_strategy.*"
      */
     public function it_uses_custom_strategy_when_configured()
     {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessageMatches('/.*custom_strategy.*/');
+
         $this->container->setParameter('kernel.bundles', ['SimpleBusCommandBusBundle'=>true, 'SimpleBusEventBusBundle'=>true]);
         $this->load(['events'=>['strategy'=>['strategy_service_id'=>'custom_strategy']]]);
     }
 
     /**
      * @test
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp ".*SimpleBusCommandBusBundle.*"
      */
     public function it_throws_exception_if_command_bus_bundle_is_missing()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/.*SimpleBusCommandBusBundle.*/');
+
         $this->container->setParameter('kernel.bundles', ['SimpleBusEventBusBundle'=>true]);
         $this->load(['events'=>['strategy'=>'predefined']]);
     }
 
     /**
      * @test
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp ".*SimpleBusEventBusBundle.*"
      */
     public function it_throws_exception_if_event_bus_bundle_is_missing()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/.*SimpleBusEventBusBundle.*/');
+
         $this->container->setParameter('kernel.bundles', ['SimpleBusCommandBusBundle'=>true]);
         $this->load(['events'=>['strategy'=>'predefined']]);
     }

--- a/Bundle/JMSSerializerBundleBridge/.travis.yml
+++ b/Bundle/JMSSerializerBundleBridge/.travis.yml
@@ -12,14 +12,19 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
     - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
 
 env:
   global:

--- a/Bundle/JMSSerializerBundleBridge/composer.json
+++ b/Bundle/JMSSerializerBundleBridge/composer.json
@@ -26,13 +26,13 @@
     ],
     "require": {
         "php": "^7.3",
-        "jms/serializer-bundle": "~0.11 || ~1.0 || ~2.0 || ~3.0",
-        "simple-bus/asynchronous-bundle": "~3.0",
-        "simple-bus/jms-serializer-bridge": "~2.0",
-        "symfony/framework-bundle": "~3.3 || ~4.0"
+        "jms/serializer-bundle": "^3.0",
+        "simple-bus/asynchronous-bundle": "^3.0",
+        "simple-bus/jms-serializer-bridge": "^2.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/Bundle/JMSSerializerBundleBridge/tests/Functional/JMSSerializerMessageSerializerTest.php
+++ b/Bundle/JMSSerializerBundleBridge/tests/Functional/JMSSerializerMessageSerializerTest.php
@@ -12,7 +12,7 @@ class JMSSerializerMessageSerializerTest extends KernelTestCase
         return 'SimpleBus\JMSSerializerBundleBridge\Tests\Functional\TestKernel';
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Bundle/RabbitMQBundleBridge/.travis.yml
+++ b/Bundle/RabbitMQBundleBridge/.travis.yml
@@ -17,14 +17,19 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
     - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
 
 env:
   global:

--- a/Bundle/RabbitMQBundleBridge/composer.json
+++ b/Bundle/RabbitMQBundleBridge/composer.json
@@ -28,21 +28,21 @@
     ],
     "require": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0",
-        "php-amqplib/rabbitmq-bundle": "~1.10",
-        "simple-bus/asynchronous": "~3.0",
-        "simple-bus/asynchronous-bundle": "~3.0",
-        "simple-bus/message-bus": "~3.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0"
+        "beberlei/assert": "^3.0",
+        "php-amqplib/rabbitmq-bundle": "^1.10",
+        "simple-bus/asynchronous": "^3.0",
+        "simple-bus/asynchronous-bundle": "^3.0",
+        "simple-bus/message-bus": "^3.0",
+        "symfony/monolog-bundle": "^3.4"
     },
     "require-dev": {
-        "matthiasnoback/phpunit-asynchronicity": "~1.0",
-        "phpunit/phpunit": "^5.7 || ^6.0",
+        "matthiasnoback/phpunit-asynchronicity": "^2.0",
+        "phpunit/phpunit": "^8.2.3",
         "simple-bus/jms-serializer-bundle-bridge": "~3.0",
-        "symfony/console": "~3.3 || ~4.0",
-        "symfony/finder": "~3.3 || ~4.0",
-        "symfony/process": "~3.3 || ~4.0",
-        "symfony/translation": "~3.3 || ~4.0"
+        "symfony/console": "^4.4 || ^5.0",
+        "symfony/finder": "^4.4 || ^5.0",
+        "symfony/process": "^4.4 || ^5.0",
+        "symfony/translation": "^4.4 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/Bundle/RabbitMQBundleBridge/src/Event/AbstractMessageEvent.php
+++ b/Bundle/RabbitMQBundleBridge/src/Event/AbstractMessageEvent.php
@@ -3,7 +3,7 @@
 namespace SimpleBus\RabbitMQBundleBridge\Event;
 
 use PhpAmqpLib\Message\AMQPMessage;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class AbstractMessageEvent extends Event
 {
@@ -22,7 +22,7 @@ class AbstractMessageEvent extends Event
         return $this->message;
     }
 
-    public function stopPropagation()
+    public function stopPropagation() : void
     {
         throw new \BadMethodCallException('Propagation should not be stopped');
     }

--- a/Bundle/RabbitMQBundleBridge/src/RabbitMQMessageConsumer.php
+++ b/Bundle/RabbitMQBundleBridge/src/RabbitMQMessageConsumer.php
@@ -35,15 +35,15 @@ class RabbitMQMessageConsumer implements ConsumerInterface
             $this->consumer->consume($msg->body);
 
             $this->eventDispatcher->dispatch(
-                Events::MESSAGE_CONSUMED,
-                new MessageConsumed($msg)
+                new MessageConsumed($msg),
+                Events::MESSAGE_CONSUMED
             );
 
             return self::MSG_ACK;
         } catch (Exception $exception) {
             $this->eventDispatcher->dispatch(
-                Events::MESSAGE_CONSUMPTION_FAILED,
-                new MessageConsumptionFailed($msg, $exception)
+                new MessageConsumptionFailed($msg, $exception),
+                Events::MESSAGE_CONSUMPTION_FAILED
             );
 
             return self::MSG_REJECT;

--- a/Bundle/RabbitMQBundleBridge/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
+++ b/Bundle/RabbitMQBundleBridge/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
@@ -20,7 +20,7 @@ class AdditionalPropertiesResolverPassTest extends TestCase
      */
     private $delegatingDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->delegatingDefinition = new Definition('stdClass', array(array()));

--- a/Bundle/RabbitMQBundleBridge/tests/Functional/SimpleBusRabbitMQBundleTest.php
+++ b/Bundle/RabbitMQBundleBridge/tests/Functional/SimpleBusRabbitMQBundleTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
+use Asynchronicity\PHPUnit\Eventually;
 use SimpleBus\Asynchronous\Properties\DelegatingAdditionalPropertiesResolver;
 use SimpleBus\Message\Bus\MessageBus;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -35,7 +36,7 @@ class SimpleBusRabbitMQBundleTest extends KernelTestCase
         return 'SimpleBus\RabbitMQBundleBridge\Tests\Functional\TestKernel';
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel();
 
@@ -43,7 +44,7 @@ class SimpleBusRabbitMQBundleTest extends KernelTestCase
         $this->logger->clearFile();
 
         $process = new Process(
-            'php console.php rabbitmq:setup-fabric',
+            ['php', 'console.php', 'rabbitmq:setup-fabric'],
             __DIR__
         );
         $process->run();
@@ -134,22 +135,6 @@ class SimpleBusRabbitMQBundleTest extends KernelTestCase
      */
     private function waitUntilLogFileContains($message)
     {
-        // Namespace was changed in matthiasnoback/phpunit-asynchronicity 2.0
-        if (class_exists(\Asynchronicity\PHPUnit\Eventually::class)) {
-            self::assertThat(
-                function () use ($message) {
-
-                    return $this->logger->fileContains(
-                        $message
-                    );
-                },
-                new \Asynchronicity\PHPUnit\Eventually($this->timeoutMs, 100),
-                sprintf('The log file does not contain "%s"', $message)
-            );
-
-            return;
-        }
-
         self::assertThat(
             function () use ($message) {
 
@@ -157,7 +142,7 @@ class SimpleBusRabbitMQBundleTest extends KernelTestCase
                     $message
                 );
             },
-            new \Matthias\PhpUnitAsynchronicity\Eventually($this->timeoutMs, 100),
+            new Eventually($this->timeoutMs, 100),
             sprintf('The log file does not contain "%s"', $message)
         );
     }
@@ -201,14 +186,14 @@ class SimpleBusRabbitMQBundleTest extends KernelTestCase
     private function consumeMessagesFromQueue($queue)
     {
         $this->process = new Process(
-            'php console.php rabbitmq:consumer ' . $queue,
+            ['php', 'console.php', 'rabbitmq:consumer', $queue],
             __DIR__
         );
 
         $this->process->start();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Bundle/RabbitMQBundleBridge/tests/RabbitMQMessageConsumerTest.php
+++ b/Bundle/RabbitMQBundleBridge/tests/RabbitMQMessageConsumerTest.php
@@ -71,11 +71,13 @@ class RabbitMQMessageConsumerTest extends TestCase
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->will($this->returnCallback(function ($name, MessageConsumptionFailed $event) use ($message, $exception) {
+            ->willReturnCallback(function (MessageConsumptionFailed $event, string $name) use ($message, $exception) {
                 $this->assertSame(Events::MESSAGE_CONSUMPTION_FAILED, $name);
                 $this->assertSame($message, $event->message());
                 $this->assertSame($exception, $event->exception());
-            }));
+
+                return $event;
+            });
 
         return $eventDispatcher;
     }
@@ -87,10 +89,12 @@ class RabbitMQMessageConsumerTest extends TestCase
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->will($this->returnCallback(function ($name, MessageConsumed $event) use ($message) {
+            ->willReturnCallback(function (MessageConsumed $event, string $name) use ($message) {
                 $this->assertSame(Events::MESSAGE_CONSUMED, $name);
                 $this->assertSame($message, $event->message());
-            }));
+
+                return $event;
+            });
 
         return $eventDispatcher;
     }

--- a/Bundle/SymfonyBridge/.travis.yml
+++ b/Bundle/SymfonyBridge/.travis.yml
@@ -12,16 +12,23 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
     # Test Symfony versions
     - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
       env: SYMFONY_VERSION=4.4.*
     - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.3
       env: SYMFONY_VERSION=4.4.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.* REMOVE_PROXY_BRIDGE="yes" EXTRA_PHPUNIT_PARAMS="--group SymfonyBridgeProxyManagerDependency"
 
 env:
   global:

--- a/Bundle/SymfonyBridge/composer.json
+++ b/Bundle/SymfonyBridge/composer.json
@@ -27,21 +27,24 @@
     ],
     "require": {
         "php": "^7.3",
-        "simple-bus/message-bus": "~3.0",
-        "symfony/config": "~3.3 || ~4.0",
-        "symfony/dependency-injection": "~3.3 || ~4.0",
-        "symfony/http-kernel": "~3.3 || ~4.0",
-        "symfony/yaml": "~3.3 || ~4.0"
+        "simple-bus/message-bus": "^3.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/yaml": "^4.4 || ^5.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/orm": "~2.5",
-        "phpunit/phpunit": "^5.7 || ^6.0",
-        "simple-bus/doctrine-orm-bridge": "~5.0",
-        "symfony/framework-bundle": "~3.3 || ~4.0",
-        "symfony/monolog-bridge": "~3.3 || ~4.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0",
-        "symfony/proxy-manager-bridge": "~3.3 || ~4.0"
+        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/orm": "^2.7",
+        "phpunit/phpunit": "^8.5",
+        "simple-bus/doctrine-orm-bridge": "^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/monolog-bridge": "^4.4 || ^5.0",
+        "symfony/monolog-bundle": "^3.4",
+        "symfony/proxy-manager-bridge": "^4.4 || ^5.0"
+    },
+    "conflict": {
+        "zendframework/zend-code": "<3.3.1"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For integration with Doctrine ORM",

--- a/Bundle/SymfonyBridge/tests/Functional/NestedCommandExecutionOrderConfigurationTest.php
+++ b/Bundle/SymfonyBridge/tests/Functional/NestedCommandExecutionOrderConfigurationTest.php
@@ -75,7 +75,7 @@ final class NestedCommandExecutionOrderConfigurationTest extends KernelTestCase
     }
 
     /** {@inheritdoc} */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/Bundle/SymfonyBridge/tests/Functional/SmokeTest.php
+++ b/Bundle/SymfonyBridge/tests/Functional/SmokeTest.php
@@ -4,6 +4,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
+use LogicException;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoCommand1;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoCommand2;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEvent1;
@@ -23,7 +24,7 @@ class SmokeTest extends KernelTestCase
         return TestKernel::class;
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 
@@ -54,12 +55,12 @@ class SmokeTest extends KernelTestCase
 
         // it has logged some things
         $loggedMessages = file_get_contents($container->getParameter('log_file'));
-        $this->assertContains('command_bus.DEBUG: Started handling a message', $loggedMessages);
-        $this->assertContains('command_bus.DEBUG: Finished handling a message', $loggedMessages);
-        $this->assertContains('event_bus.DEBUG: Started handling a message', $loggedMessages);
-        $this->assertContains('event_bus.DEBUG: Finished handling a message', $loggedMessages);
-        $this->assertContains('event_bus.DEBUG: Started notifying a subscriber', $loggedMessages);
-        $this->assertContains('event_bus.DEBUG: Finished notifying a subscriber', $loggedMessages);
+        $this->assertStringContainsString('command_bus.DEBUG: Started handling a message', $loggedMessages);
+        $this->assertStringContainsString('command_bus.DEBUG: Finished handling a message', $loggedMessages);
+        $this->assertStringContainsString('event_bus.DEBUG: Started handling a message', $loggedMessages);
+        $this->assertStringContainsString('event_bus.DEBUG: Finished handling a message', $loggedMessages);
+        $this->assertStringContainsString('event_bus.DEBUG: Started notifying a subscriber', $loggedMessages);
+        $this->assertStringContainsString('event_bus.DEBUG: Finished notifying a subscriber', $loggedMessages);
     }
 
     /**
@@ -136,14 +137,13 @@ class SmokeTest extends KernelTestCase
 
     /**
      * @test
-     * 
      * @group SymfonyBridgeProxyManagerDependency
-     *
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage In order to use bundle "DoctrineOrmBridgeBundle" you need to require "symfony/proxy-manager-bridge" package.
      */
     public function fails_because_of_mising_dependency()
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('In order to use bundle "DoctrineOrmBridgeBundle" you need to require "symfony/proxy-manager-bridge" package.');
+
         self::bootKernel(['environment' => 'config2']);
     }
 

--- a/Bundle/SymfonyBridge/tests/Functional/SmokeTest/TestKernel.php
+++ b/Bundle/SymfonyBridge/tests/Functional/SmokeTest/TestKernel.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use SimpleBus\SymfonyBridge\SimpleBusCommandBusBundle;
 use SimpleBus\SymfonyBridge\DoctrineOrmBridgeBundle;
 use SimpleBus\SymfonyBridge\SimpleBusEventBusBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -24,6 +25,7 @@ class TestKernel extends Kernel
     public function registerBundles()
     {
         return array(
+            new FrameworkBundle(),
             new DoctrineBundle(),
             new SimpleBusCommandBusBundle(),
             new SimpleBusEventBusBundle(),
@@ -45,6 +47,11 @@ class TestKernel extends Kernel
     public function getLogDir()
     {
         return $this->tempDir . '/logs';
+    }
+
+    public function getProjectDir()
+    {
+        return __DIR__;
     }
 
     protected function getContainerClass()

--- a/Bundle/SymfonyBridge/tests/Functional/SmokeTest/config.yml
+++ b/Bundle/SymfonyBridge/tests/Functional/SmokeTest/config.yml
@@ -2,6 +2,9 @@ services:
     annotation_reader:
         class: Doctrine\Common\Annotations\AnnotationReader
 
+framework:
+    secret: 'secret'
+
 doctrine:
     dbal:
         driver: pdo_sqlite
@@ -14,7 +17,7 @@ doctrine:
                 mappings:
                     test:
                         type: annotation
-                        dir: "%kernel.root_dir%/Entity/"
+                        dir: "%kernel.project_dir%/Entity/"
                         prefix: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Entity
                         alias: Test
                         is_bundle: false

--- a/Bundle/SymfonyBridge/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
+++ b/Bundle/SymfonyBridge/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
@@ -27,7 +27,7 @@ class ConfigureMiddlewaresTest extends TestCase
      */
     private $mainBusDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->mainBusDefinition = new Definition('stdClass');

--- a/Component/Asynchronous/.travis.yml
+++ b/Component/Asynchronous/.travis.yml
@@ -12,8 +12,10 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
+
 env:
   global:
     - COMPOSER_FLAGS=""

--- a/Component/Asynchronous/composer.json
+++ b/Component/Asynchronous/composer.json
@@ -27,13 +27,13 @@
     ],
     "require": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0",
-        "psr/log": "~1.0",
-        "simple-bus/message-bus": "~3.0",
-        "simple-bus/serialization": "~3.0"
+        "beberlei/assert": "^3.0",
+        "psr/log": "^1.0",
+        "simple-bus/message-bus": "~^.0",
+        "simple-bus/serialization": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/Component/MessageBus/.travis.yml
+++ b/Component/MessageBus/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
   global:

--- a/Component/MessageBus/composer.json
+++ b/Component/MessageBus/composer.json
@@ -27,11 +27,11 @@
     ],
     "require": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0",
-        "psr/log": "~1.0"
+        "beberlei/assert": "^3.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/Component/MessageBus/tests/CallableResolver/CallableCollectionTest.php
+++ b/Component/MessageBus/tests/CallableResolver/CallableCollectionTest.php
@@ -13,7 +13,7 @@ class CallableCollectionTest extends TestCase
      */
     private $callableResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->callableResolver = $this->createMock('SimpleBus\Message\CallableResolver\CallableResolver');
     }

--- a/Component/MessageBus/tests/CallableResolver/CallableMapTest.php
+++ b/Component/MessageBus/tests/CallableResolver/CallableMapTest.php
@@ -14,7 +14,7 @@ class CallableMapTest extends TestCase
     private $callableResolver;
     private $map;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->callableResolver = $this->createMock('SimpleBus\Message\CallableResolver\CallableResolver');
     }

--- a/Component/MessageBus/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
+++ b/Component/MessageBus/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
@@ -19,7 +19,7 @@ class ServiceLocatorAwareCallableResolverTest extends TestCase
 
     private $serviceLocator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->services = [];
         $this->serviceLocator = function ($serviceId) {

--- a/Component/Serialization/.travis.yml
+++ b/Component/Serialization/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-  allow_failures:
-    - env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.4
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
   global:

--- a/Component/Serialization/composer.json
+++ b/Component/Serialization/composer.json
@@ -26,10 +26,10 @@
     ],
     "require": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0"
+        "beberlei/assert": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^6.0"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/Component/Serialization/tests/NativeObjectSerializerTest.php
+++ b/Component/Serialization/tests/NativeObjectSerializerTest.php
@@ -21,7 +21,7 @@ class NativeObjectSerializerTest extends TestCase
         $serializer = new NativeObjectSerializer();
 
         $serializedEnvelope = $serializedEnvelope = $serializer->serialize($envelope);
-        $this->assertInternalType('string', $serializedEnvelope);
+        $this->assertIsString($serializedEnvelope);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -23,29 +23,39 @@
             "homepage": "http://php-and-symfony.matthiasnoback.nl"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mihaileu/RabbitMqBundle.git"
+        }
+    ],
     "require-dev": {
         "php": "^7.3",
-        "beberlei/assert": "~2.0 || ~3.0",
-        "doctrine/dbal": "~2.5",
-        "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/orm": "~2.5",
-        "jms/serializer-bundle": "~0.11 || ~1.0 || ~2.0 || ~3.0",
-        "matthiasnoback/doctrine-orm-test-service-provider": "~3.0",
-        "matthiasnoback/phpunit-asynchronicity": "~1.0 || ~2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "~1.2 || ~2.0",
-        "php-amqplib/rabbitmq-bundle": "~1.10",
-        "phpunit/phpunit": "^5.7 || ^6.0",
-        "psr/log": "~1.0",
-        "symfony/config": "~3.3 || ~4.0",
-        "symfony/console": "~3.3 || ~4.0",
-        "symfony/dependency-injection": "~3.3 || ~4.0",
-        "symfony/finder": "~3.3 || ~4.0",
-        "symfony/framework-bundle": "~3.3 || ~4.0",
-        "symfony/http-kernel": "~3.3 || ~4.0",
-        "symfony/monolog-bundle": "~2.3 || ~3.0",
-        "symfony/process": "~3.3 || ~4.0",
-        "symfony/proxy-manager-bridge": "~3.3 || ~4.0",
-        "symfony/yaml": "~3.3 || ~4.0"
+        "beberlei/assert": "^3.0",
+        "doctrine/dbal": "^2.5",
+        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/orm": "^2.7",
+        "jms/serializer": "^3.2.0",
+        "jms/serializer-bundle": "^3.0",
+        "matthiasnoback/doctrine-orm-test-service-provider": "^3.0",
+        "matthiasnoback/phpunit-asynchronicity": "^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "php-amqplib/rabbitmq-bundle": "dev-allow_symfony_5#2101dada07bd8424dc628bc9f8b173064205198a",
+        "phpunit/phpunit": "^8.5",
+        "psr/log": "^1.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/console": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/finder": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/monolog-bundle": "^3.4",
+        "symfony/process": "^4.4 || ^5.0",
+        "symfony/proxy-manager-bridge": "^4.4 || ^5.0",
+        "symfony/yaml": "^4.4 || ^5.0"
+    },
+    "conflict": {
+        "zendframework/zend-code": "<3.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     </php>
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Everything">
             <directory>./Bridge/*/tests/</directory>
             <directory>./Bundle/*/tests/</directory>
             <directory>./Component/*/tests/</directory>


### PR DESCRIPTION
In order to get it working, I needed to use https://github.com/php-amqplib/RabbitMqBundle/pull/605. This has been added as a fork in composer.json. When the PR is merged, we can remove this again.

The plan is to merge this soon to master, so that people can upgrade to Symfony 5 by requiring `dev-master`. 

