### PR TITLE
[AutoRegister] Add support for PHP 8 union types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,5 +107,10 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "cs": "vendor/bin/php-cs-fixer fix",
+        "phpstan": "vendor/bin/phpstan",
+        "tests": "vendor/bin/phpunit"
+    }
 }

--- a/docs/Symfony/event-bus-bundle.rst
+++ b/docs/Symfony/event-bus-bundle.rst
@@ -158,6 +158,23 @@ With the following code for the subscriber:
 SimpleBus automatically detects that ``ElasticSearchSubscriber`` wants to subscribe to both
 ``EventAddedEvent`` and ``VenueAddedEvent``.
 
+If you use PHP 8.0 you can also use union types like this:
+
+.. code-block::  php
+
+    namespace App\Subscriber;
+
+    use App\Event\EventAddedEvent;
+    use App\Event\VenueAddedEvent;
+
+    class ElasticSearchSubscriber
+    {
+        public function onEvent(VenueAddedEvent | EventAddedEvent $event)
+        {
+            // Add the Venue or Event to ElasticSearch
+        }
+    }
+
 Setting the event name resolving strategy
 -----------------------------------------
 

--- a/packages/symfony-bridge/tests/Functional/Php8SmokeTest.php
+++ b/packages/symfony-bridge/tests/Functional/Php8SmokeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional;
+
+use SimpleBus\Message\Bus\MessageBus;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEvent2;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEvent3;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriberUsingPublicMethodAndUnion;
+use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ * @requires PHP 8.0
+ */
+class Php8SmokeTest extends KernelTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        static::$class = null;
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAutoRegisterEventSubscribersUsingPublicMethodAndUnion(): void
+    {
+        self::bootKernel(['environment' => 'config2_php8']);
+        $container = self::$kernel->getContainer();
+
+        $event2 = new AutoEvent2();
+        $event3 = new AutoEvent3();
+
+        $this->assertFalse($event2->isHandledBy(AutoEventSubscriberUsingPublicMethodAndUnion::class));
+        $this->assertFalse($event3->isHandledBy(AutoEventSubscriberUsingPublicMethodAndUnion::class));
+
+        $eventBus = $container->get('event_bus');
+
+        $this->assertInstanceOf(MessageBus::class, $eventBus);
+
+        $eventBus->handle($event2);
+        $eventBus->handle($event3);
+
+        $this->assertTrue($event2->isHandledBy(AutoEventSubscriberUsingPublicMethodAndUnion::class));
+        $this->assertTrue($event3->isHandledBy(AutoEventSubscriberUsingPublicMethodAndUnion::class));
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+}

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/Auto/AutoEventSubscriberUsingPublicMethodAndUnion.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/Auto/AutoEventSubscriberUsingPublicMethodAndUnion.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto;
+
+final class AutoEventSubscriberUsingPublicMethodAndUnion
+{
+    public function __invoke(AutoEvent2 | AutoEvent3 $event): void
+    {
+        $event->setHandledBy($this);
+    }
+}

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/config2_php8.yml
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/config2_php8.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: config.yml }
+
+services:
+    auto_event_subscriber_using_public_method_and_union:
+        class: SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriberUsingPublicMethodAndUnion
+        tags:
+            - { name: event_subscriber, register_public_methods: true }
+        public: false

--- a/phpstan.conditional.php
+++ b/phpstan.conditional.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+$config = [];
+
+if (PHP_VERSION_ID < 8_00_00) {
+    // Change of signature in PHP 8.0
+    $config['parameters']['excludes_analyse'][] = 'packages/symfony-bridge/tests/Functional/Php8SmokeTest.php';
+    $config['parameters']['excludes_analyse'][] = 'packages/symfony-bridge/tests/Functional/SmokeTest/Auto/AutoEventSubscriberUsingPublicMethodAndUnion.php';
+}
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - phpstan.conditional.php
     - phpstan-baseline.neon
     - phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:


### PR DESCRIPTION
This makes it possible to auto wire a subscriber that listens to multiple events using:
```php
    class Subscriber
    {
        public function __invoke(VenueAddedEvent | EventAddedEvent $event)
        {
            // Add the Venue or Event
        }
    }
```