### PR TITLE
PHP CS Fixer > Exclude `temp` directory

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,6 +3,7 @@
 $finder = PhpCsFixer\Finder::create()
     ->in('src')
     ->in('packages')
+    ->exclude('temp')
 ;
 
 $config = (new PhpCsFixer\Config())


### PR DESCRIPTION
No need to reformat generated PHP code from Symfony functional tests.