### PR TITLE
Drop Symfony 5.3 and add support for Symfony 6.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
             -   id: set-php-version
                 run: echo "::set-output name=php-version::$(vendor/bin/easy-ci php-versions-json | sed 's/]$/,"8.1"]/')"
             -   id: set-symfony-version
-                run: echo '::set-output name=symfony-version::["5.3.*", "5.4.*"]'
+                run: echo '::set-output name=symfony-version::["5.4.*", "6.0.*"]'
         outputs:
             packages: ${{ steps.set-packages.outputs.packages }}
             php-version: ${{ steps.set-php-version.outputs.php-version }}
@@ -47,17 +47,17 @@ jobs:
                 include:
                     -   php-version: '8.0'
                         package: 'symfony-bridge'
-                        symfony-version: '5.3.*'
+                        symfony-version: '5.4.*'
                         dependencies: 'lowest'
                         remove-dependencies: '--dev symfony/proxy-manager-bridge'
                 exclude:
                     # Only test once it has no Symfony packages
                     -   package: 'asynchronous'
-                        symfony-version: '4.4.*'
+                        symfony-version: '5.4.*'
                     -   package: 'message-bus'
-                        symfony-version: '4.4.*'
+                        symfony-version: '5.4.*'
                     -   package: 'serialization'
-                        symfony-version: '4.4.*'
+                        symfony-version: '5.4.*'
         services:
             rabbitmq:
                 image: rabbitmq:3.8-alpine

--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
         "jms/serializer": "^3.15",
         "jms/serializer-bundle": "^4.0",
         "php-amqplib/php-amqplib": "^3.1",
-        "php-amqplib/rabbitmq-bundle": "^2.6",
+        "php-amqplib/rabbitmq-bundle": "^2.11.0",
         "psr/log": "^1.1.4 || ^2.0 || ^3.0",
-        "symfony/config": "^5.3.7 || ^5.4",
-        "symfony/dependency-injection": "^5.3.7 || ^5.4",
-        "symfony/framework-bundle": "^5.3.7 || ^5.4",
-        "symfony/http-kernel": "^5.3.7 || ^5.4",
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
         "symfony/monolog-bundle": "^3.4",
-        "symfony/yaml": "^5.3.7 || ^5.4"
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "replace": {
         "simple-bus/asynchronous": "self.version",
@@ -52,7 +52,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "doctrine/doctrine-bundle": "^2.2",
+        "doctrine/doctrine-bundle": "^2.5",
         "friendsofphp/php-cs-fixer": "^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "matthiasnoback/phpunit-asynchronicity": "^2.4",
@@ -63,23 +63,27 @@
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5.5",
         "pimple/pimple": "^3.5",
-        "symfony/cache": "^5.3.7 || ^5.4",
-        "symfony/console": "^5.3.7 || ^5.4",
-        "symfony/finder": "^5.3.7 || ^5.4",
-        "symfony/monolog-bridge": "^5.3.7 || ^5.4",
+        "symfony/cache": "^5.4 || ^6.0",
+        "symfony/console": "^5.4 || ^6.0",
+        "symfony/finder": "^5.4 || ^6.0",
+        "symfony/monolog-bridge": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/process": "^5.3.7 || ^5.4",
-        "symfony/proxy-manager-bridge": "^5.3.7 || ^5.4",
-        "symfony/stopwatch": "^5.3.7 || ^5.4",
-        "symfony/translation": "^5.3.7 || ^5.4",
-        "symplify/easy-ci": "^9.0",
-        "symplify/monorepo-builder": "^9.0"
+        "symfony/process": "^5.4 || ^6.0",
+        "symfony/proxy-manager-bridge": "^5.4 || ^6.0",
+        "symfony/stopwatch": "^5.4 || ^6.0",
+        "symfony/translation": "^5.4 || ^6.0",
+        "symplify/easy-ci": "^10.0",
+        "symplify/monorepo-builder": "^10.0"
     },
     "conflict": {
         "friendsofphp/proxy-manager-lts": "<1.0.5"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -13,8 +13,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::DATA_TO_APPEND, [
         ComposerJsonSection::REQUIRE_DEV => [
             'phpunit/phpunit' => '^9.5.5',
-            'symplify/monorepo-builder' => '^9.0',
+            'symplify/monorepo-builder' => '^10.0',
         ],
     ]);
-    $parameters->set(Option::PACKAGE_DIRECTORIES, [__DIR__ . '/packages']);
+    $parameters->set(Option::PACKAGE_DIRECTORIES, [__DIR__.'/packages']);
 };

--- a/packages/asynchronous-bundle/composer.json
+++ b/packages/asynchronous-bundle/composer.json
@@ -31,9 +31,9 @@
         "simple-bus/asynchronous": "^6.0",
         "simple-bus/message-bus": "^6.0",
         "simple-bus/symfony-bridge": "^6.0",
-        "symfony/config": "^5.3.7 || ^5.4",
-        "symfony/dependency-injection": "^5.3.7 || ^5.4",
-        "symfony/framework-bundle": "^5.3.7 || ^5.4"
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "conflict": {
         "monolog/monolog": "<1.26.1 || >=2.0,<2.3.0"

--- a/packages/doctrine-orm-bridge/composer.json
+++ b/packages/doctrine-orm-bridge/composer.json
@@ -38,7 +38,7 @@
         "ergebnis/composer-normalize": "^2.11",
         "phpunit/phpunit": "^9.5.5",
         "pimple/pimple": "^3.5",
-        "symfony/cache": "^5.3.7 || ^5.4",
+        "symfony/cache": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.0"
     },
     "suggest": {

--- a/packages/jms-serializer-bridge/composer.json
+++ b/packages/jms-serializer-bridge/composer.json
@@ -36,7 +36,7 @@
         "ergebnis/composer-normalize": "^2.11",
         "phpunit/phpunit": "^9.5.5",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/yaml": "^5.3.7 || ^5.4"
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "config": {
         "sort-packages": true

--- a/packages/jms-serializer-bundle-bridge/composer.json
+++ b/packages/jms-serializer-bundle-bridge/composer.json
@@ -29,9 +29,9 @@
         "jms/serializer-bundle": "^4.0",
         "simple-bus/asynchronous-bundle": "^6.0",
         "simple-bus/jms-serializer-bridge": "^6.0",
-        "symfony/config": "^5.3.7 || ^5.4",
-        "symfony/dependency-injection": "^5.3.7 || ^5.4",
-        "symfony/framework-bundle": "^5.3.7 || ^5.4"
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "conflict": {
         "doctrine/annotations": "<1.10.4",

--- a/packages/rabbitmq-bundle-bridge/composer.json
+++ b/packages/rabbitmq-bundle-bridge/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.0",
         "php-amqplib/php-amqplib": "^3.1",
-        "php-amqplib/rabbitmq-bundle": "^2.6",
+        "php-amqplib/rabbitmq-bundle": "^2.11.0",
         "simple-bus/asynchronous": "^6.0",
         "simple-bus/asynchronous-bundle": "^6.0",
         "simple-bus/message-bus": "^6.0",
@@ -44,12 +44,12 @@
         "matthiasnoback/phpunit-asynchronicity": "^2.4",
         "phpunit/phpunit": "^9.5.5",
         "simple-bus/jms-serializer-bundle-bridge": "^6.0",
-        "symfony/console": "^5.3.7 || ^5.4",
-        "symfony/finder": "^5.3.7 || ^5.4",
+        "symfony/console": "^5.4 || ^6.0",
+        "symfony/finder": "^5.4 || ^6.0",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/process": "^5.3.7 || ^5.4",
-        "symfony/stopwatch": "^5.3.7 || ^5.4",
-        "symfony/translation": "^5.3.7 || ^5.4"
+        "symfony/process": "^5.4 || ^6.0",
+        "symfony/stopwatch": "^5.4 || ^6.0",
+        "symfony/translation": "^5.4 || ^6.0"
     },
     "config": {
         "sort-packages": true

--- a/packages/symfony-bridge/composer.json
+++ b/packages/symfony-bridge/composer.json
@@ -28,10 +28,10 @@
     "require": {
         "php": "^8.0",
         "simple-bus/message-bus": "^6.0",
-        "symfony/config": "^5.3.7 || ^5.4",
-        "symfony/dependency-injection": "^5.3.7 || ^5.4",
-        "symfony/http-kernel": "^5.3.7 || ^5.4",
-        "symfony/yaml": "^5.3.7 || ^5.4"
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13.3",
@@ -41,18 +41,18 @@
         "zendframework/zend-code": "<3.3.1"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.2",
+        "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.8.5",
         "ergebnis/composer-normalize": "^2.11",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "laminas/laminas-code": "^4.5",
         "phpunit/phpunit": "^9.5.5",
         "simple-bus/doctrine-orm-bridge": "^6.0",
-        "symfony/framework-bundle": "^5.3.7 || ^5.4",
-        "symfony/monolog-bridge": "^5.3.7 || ^5.4",
+        "symfony/framework-bundle": "^5.4 || ^6.0",
+        "symfony/monolog-bridge": "^5.4 || ^6.0",
         "symfony/monolog-bundle": "^3.4",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/proxy-manager-bridge": "^5.3.7 || ^5.4"
+        "symfony/proxy-manager-bridge": "^5.4 || ^6.0"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "For integration with Doctrine ORM",


### PR DESCRIPTION
Blocked by:
- https://github.com/php-amqplib/RabbitMqBundle/pull/675