### PR TITLE
Make everything final

### DIFF
--- a/packages/asynchronous-bundle/src/DependencyInjection/Compiler/CollectAsynchronousEventNames.php
+++ b/packages/asynchronous-bundle/src/DependencyInjection/Compiler/CollectAsynchronousEventNames.php
@@ -6,7 +6,7 @@ use SimpleBus\SymfonyBridge\DependencyInjection\Compiler\CollectServices;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class CollectAsynchronousEventNames implements CompilerPassInterface
+final class CollectAsynchronousEventNames implements CompilerPassInterface
 {
     use CollectServices;
 

--- a/packages/asynchronous-bundle/src/DependencyInjection/Configuration.php
+++ b/packages/asynchronous-bundle/src/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ namespace SimpleBus\AsynchronousBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     private string $alias;
 

--- a/packages/asynchronous-bundle/src/DependencyInjection/SimpleBusAsynchronousExtension.php
+++ b/packages/asynchronous-bundle/src/DependencyInjection/SimpleBusAsynchronousExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class SimpleBusAsynchronousExtension extends ConfigurableExtension
+final class SimpleBusAsynchronousExtension extends ConfigurableExtension
 {
     private string $alias;
 

--- a/packages/asynchronous-bundle/src/SimpleBusAsynchronousBundle.php
+++ b/packages/asynchronous-bundle/src/SimpleBusAsynchronousBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SimpleBusAsynchronousBundle extends Bundle
+final class SimpleBusAsynchronousBundle extends Bundle
 {
     public function getContainerExtension(): SimpleBusAsynchronousExtension
     {

--- a/packages/asynchronous-bundle/tests/Functional/CommandHandler.php
+++ b/packages/asynchronous-bundle/tests/Functional/CommandHandler.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
-class CommandHandler
+final class CommandHandler
 {
     private Spy $spy;
 

--- a/packages/asynchronous-bundle/tests/Functional/DummyCommand.php
+++ b/packages/asynchronous-bundle/tests/Functional/DummyCommand.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
-class DummyCommand
+final class DummyCommand
 {
 }

--- a/packages/asynchronous-bundle/tests/Functional/DummyEvent.php
+++ b/packages/asynchronous-bundle/tests/Functional/DummyEvent.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
-class DummyEvent
+final class DummyEvent
 {
 }

--- a/packages/asynchronous-bundle/tests/Functional/EventSubscriber.php
+++ b/packages/asynchronous-bundle/tests/Functional/EventSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
-class EventSubscriber
+final class EventSubscriber
 {
     private Spy $spy;
 

--- a/packages/asynchronous-bundle/tests/Functional/MessageConsumer.php
+++ b/packages/asynchronous-bundle/tests/Functional/MessageConsumer.php
@@ -4,7 +4,7 @@ namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
 use SimpleBus\Asynchronous\Consumer\StandardSerializedEnvelopeConsumer;
 
-class MessageConsumer
+final class MessageConsumer
 {
     private StandardSerializedEnvelopeConsumer $consumer;
 

--- a/packages/asynchronous-bundle/tests/Functional/PublisherSpy.php
+++ b/packages/asynchronous-bundle/tests/Functional/PublisherSpy.php
@@ -4,7 +4,7 @@ namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
 use SimpleBus\Asynchronous\Publisher\Publisher;
 
-class PublisherSpy implements Publisher
+final class PublisherSpy implements Publisher
 {
     /**
      * @var object[]

--- a/packages/asynchronous-bundle/tests/Functional/SimpleBusAsynchronousBundleTest.php
+++ b/packages/asynchronous-bundle/tests/Functional/SimpleBusAsynchronousBundleTest.php
@@ -6,7 +6,7 @@ use SimpleBus\Message\Bus\MessageBus;
 use SimpleBus\Serialization\Envelope\DefaultEnvelope;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class SimpleBusAsynchronousBundleTest extends KernelTestCase
+final class SimpleBusAsynchronousBundleTest extends KernelTestCase
 {
     protected function tearDown(): void
     {

--- a/packages/asynchronous-bundle/tests/Functional/Spy.php
+++ b/packages/asynchronous-bundle/tests/Functional/Spy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleBus\AsynchronousBundle\Tests\Functional;
 
-class Spy
+final class Spy
 {
     /**
      * @var object[]

--- a/packages/asynchronous-bundle/tests/Functional/TestKernel.php
+++ b/packages/asynchronous-bundle/tests/Functional/TestKernel.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-class TestKernel extends Kernel
+final class TestKernel extends Kernel
 {
     private string $tempDir;
 

--- a/packages/asynchronous-bundle/tests/Unit/DepencencyInjection/Compiler/CollectAsynchronousEventNamesTest.php
+++ b/packages/asynchronous-bundle/tests/Unit/DepencencyInjection/Compiler/CollectAsynchronousEventNamesTest.php
@@ -7,7 +7,7 @@ use SimpleBus\AsynchronousBundle\DependencyInjection\Compiler\CollectAsynchronou
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class CollectAsynchronousEventNamesTest extends AbstractCompilerPassTestCase
+final class CollectAsynchronousEventNamesTest extends AbstractCompilerPassTestCase
 {
     /**
      * @test

--- a/packages/asynchronous-bundle/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
+++ b/packages/asynchronous-bundle/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
@@ -7,7 +7,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use SimpleBus\AsynchronousBundle\DependencyInjection\SimpleBusAsynchronousExtension;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
+final class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
 {
     /**
      * @test

--- a/packages/asynchronous/src/Consumer/StandardSerializedEnvelopeConsumer.php
+++ b/packages/asynchronous/src/Consumer/StandardSerializedEnvelopeConsumer.php
@@ -8,7 +8,7 @@ use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopeSerializer;
 /**
  * Use this consumer to easily implement an asynchronous message consumer.
  */
-class StandardSerializedEnvelopeConsumer implements SerializedEnvelopeConsumer
+final class StandardSerializedEnvelopeConsumer implements SerializedEnvelopeConsumer
 {
     private MessageInEnvelopeSerializer $messageInEnvelopeSerializer;
 

--- a/packages/asynchronous/src/MessageBus/AlwaysPublishesMessages.php
+++ b/packages/asynchronous/src/MessageBus/AlwaysPublishesMessages.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Asynchronous\MessageBus;
 use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 
-class AlwaysPublishesMessages implements MessageBusMiddleware
+final class AlwaysPublishesMessages implements MessageBusMiddleware
 {
     private Publisher $publisher;
 

--- a/packages/asynchronous/src/MessageBus/PublishesPredefinedMessages.php
+++ b/packages/asynchronous/src/MessageBus/PublishesPredefinedMessages.php
@@ -6,7 +6,7 @@ use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\Name\MessageNameResolver;
 
-class PublishesPredefinedMessages implements MessageBusMiddleware
+final class PublishesPredefinedMessages implements MessageBusMiddleware
 {
     private Publisher $publisher;
 

--- a/packages/asynchronous/src/MessageBus/PublishesUnhandledMessages.php
+++ b/packages/asynchronous/src/MessageBus/PublishesUnhandledMessages.php
@@ -7,7 +7,7 @@ use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\CallableResolver\Exception\UndefinedCallable;
 
-class PublishesUnhandledMessages implements MessageBusMiddleware
+final class PublishesUnhandledMessages implements MessageBusMiddleware
 {
     private Publisher $publisher;
 

--- a/packages/asynchronous/src/Properties/DelegatingAdditionalPropertiesResolver.php
+++ b/packages/asynchronous/src/Properties/DelegatingAdditionalPropertiesResolver.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Asynchronous\Properties;
 
-class DelegatingAdditionalPropertiesResolver implements AdditionalPropertiesResolver
+final class DelegatingAdditionalPropertiesResolver implements AdditionalPropertiesResolver
 {
     /**
      * @var AdditionalPropertiesResolver[]

--- a/packages/asynchronous/src/Routing/ClassBasedRoutingKeyResolver.php
+++ b/packages/asynchronous/src/Routing/ClassBasedRoutingKeyResolver.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Asynchronous\Routing;
 
-class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
+final class ClassBasedRoutingKeyResolver implements RoutingKeyResolver
 {
     public function resolveRoutingKeyFor(object $message): string
     {

--- a/packages/asynchronous/src/Routing/EmptyRoutingKeyResolver.php
+++ b/packages/asynchronous/src/Routing/EmptyRoutingKeyResolver.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Asynchronous\Routing;
 
-class EmptyRoutingKeyResolver implements RoutingKeyResolver
+final class EmptyRoutingKeyResolver implements RoutingKeyResolver
 {
     /**
      * Always use an empty routing key.

--- a/packages/asynchronous/tests/Consumer/StandardSerializedEnvelopeConsumerTest.php
+++ b/packages/asynchronous/tests/Consumer/StandardSerializedEnvelopeConsumerTest.php
@@ -10,7 +10,7 @@ use SimpleBus\Serialization\Envelope\DefaultEnvelope;
 use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopeSerializer;
 use stdClass;
 
-class StandardSerializedEnvelopeConsumerTest extends TestCase
+final class StandardSerializedEnvelopeConsumerTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/MessageBus/AlwaysPublishesMessagesTest.php
+++ b/packages/asynchronous/tests/MessageBus/AlwaysPublishesMessagesTest.php
@@ -8,7 +8,7 @@ use SimpleBus\Asynchronous\MessageBus\AlwaysPublishesMessages;
 use SimpleBus\Asynchronous\Publisher\Publisher;
 use stdClass;
 
-class AlwaysPublishesMessagesTest extends TestCase
+final class AlwaysPublishesMessagesTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/MessageBus/PublishesPredefinedMessagesTest.php
+++ b/packages/asynchronous/tests/MessageBus/PublishesPredefinedMessagesTest.php
@@ -9,7 +9,7 @@ use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Message\Name\MessageNameResolver;
 use stdClass;
 
-class PublishesPredefinedMessagesTest extends TestCase
+final class PublishesPredefinedMessagesTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/MessageBus/PublishesUnhandledMessagesTest.php
+++ b/packages/asynchronous/tests/MessageBus/PublishesUnhandledMessagesTest.php
@@ -11,7 +11,7 @@ use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Message\CallableResolver\Exception\UndefinedCallable;
 use stdClass;
 
-class PublishesUnhandledMessagesTest extends TestCase
+final class PublishesUnhandledMessagesTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/Properties/DelegatingAdditionalPropertiesResolverTest.php
+++ b/packages/asynchronous/tests/Properties/DelegatingAdditionalPropertiesResolverTest.php
@@ -8,7 +8,7 @@ use SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver;
 use SimpleBus\Asynchronous\Properties\DelegatingAdditionalPropertiesResolver;
 use stdClass;
 
-class DelegatingAdditionalPropertiesResolverTest extends TestCase
+final class DelegatingAdditionalPropertiesResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/Routing/ClassBasedRoutingKeyResolverTest.php
+++ b/packages/asynchronous/tests/Routing/ClassBasedRoutingKeyResolverTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Asynchronous\Routing\ClassBasedRoutingKeyResolver;
 use SimpleBus\Asynchronous\Tests\Routing\Fixtures\MessageDummy;
 
-class ClassBasedRoutingKeyResolverTest extends TestCase
+final class ClassBasedRoutingKeyResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/Routing/EmptyRoutingKeyResolverTest.php
+++ b/packages/asynchronous/tests/Routing/EmptyRoutingKeyResolverTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Asynchronous\Routing\EmptyRoutingKeyResolver;
 use stdClass;
 
-class EmptyRoutingKeyResolverTest extends TestCase
+final class EmptyRoutingKeyResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/asynchronous/tests/Routing/Fixtures/MessageDummy.php
+++ b/packages/asynchronous/tests/Routing/Fixtures/MessageDummy.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\Asynchronous\Tests\Routing\Fixtures;
 
-class MessageDummy
+final class MessageDummy
 {
 }

--- a/packages/doctrine-dbal-bridge/src/MessageBus/WrapsMessageHandlingInTransaction.php
+++ b/packages/doctrine-dbal-bridge/src/MessageBus/WrapsMessageHandlingInTransaction.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Driver\Connection;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use Throwable;
 
-class WrapsMessageHandlingInTransaction implements MessageBusMiddleware
+final class WrapsMessageHandlingInTransaction implements MessageBusMiddleware
 {
     private Connection $connection;
 

--- a/packages/doctrine-dbal-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
+++ b/packages/doctrine-dbal-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
@@ -10,7 +10,7 @@ use SimpleBus\DoctrineDBALBridge\MessageBus\WrapsMessageHandlingInTransaction;
 use stdClass;
 use Throwable;
 
-class WrapsMessageHandlingInTransactionTest extends TestCase
+final class WrapsMessageHandlingInTransactionTest extends TestCase
 {
     /**
      * @test

--- a/packages/doctrine-orm-bridge/src/EventListener/CollectsEventsFromEntities.php
+++ b/packages/doctrine-orm-bridge/src/EventListener/CollectsEventsFromEntities.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Proxy\Proxy;
 use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 
-class CollectsEventsFromEntities implements EventSubscriber, ContainsRecordedMessages
+final class CollectsEventsFromEntities implements EventSubscriber, ContainsRecordedMessages
 {
     /**
      * @var object[]

--- a/packages/doctrine-orm-bridge/src/MessageBus/WrapsMessageHandlingInTransaction.php
+++ b/packages/doctrine-orm-bridge/src/MessageBus/WrapsMessageHandlingInTransaction.php
@@ -7,7 +7,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use Throwable;
 
-class WrapsMessageHandlingInTransaction implements MessageBusMiddleware
+final class WrapsMessageHandlingInTransaction implements MessageBusMiddleware
 {
     private ManagerRegistry $managerRegistry;
 

--- a/packages/doctrine-orm-bridge/tests/EventListener/CollectsEventsFromEntitiesTest.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/CollectsEventsFromEntitiesTest.php
@@ -14,7 +14,7 @@ use SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event\EntityNotDirt
 use SimpleBus\DoctrineORMBridge\Tests\PHPUnitTestServiceContainer\PHPUnit\TestCaseWithEntityManager;
 use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 
-class CollectsEventsFromEntitiesTest extends TestCase
+final class CollectsEventsFromEntitiesTest extends TestCase
 {
     use TestCaseWithEntityManager;
 

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Entity/EventRecordingEntity.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Entity/EventRecordingEntity.php
@@ -15,7 +15,7 @@ use SimpleBus\Message\Recorder\PrivateMessageRecorderCapabilities;
  * @Entity
  * @HasLifecycleCallbacks()
  */
-class EventRecordingEntity implements ContainsRecordedMessages
+final class EventRecordingEntity implements ContainsRecordedMessages
 {
     use PrivateMessageRecorderCapabilities;
 

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityAboutToBeRemoved.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityAboutToBeRemoved.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityAboutToBeRemoved
+final class EntityAboutToBeRemoved
 {
 }

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityChanged.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityChanged.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityChanged
+final class EntityChanged
 {
 }

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityChangedPreUpdate.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityChangedPreUpdate.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityChangedPreUpdate
+final class EntityChangedPreUpdate
 {
 }

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityCreated.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityCreated.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityCreated
+final class EntityCreated
 {
 }

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityCreatedPrePersist.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityCreatedPrePersist.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityCreatedPrePersist
+final class EntityCreatedPrePersist
 {
 }

--- a/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityNotDirty.php
+++ b/packages/doctrine-orm-bridge/tests/EventListener/Fixtures/Event/EntityNotDirty.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\DoctrineORMBridge\Tests\EventListener\Fixtures\Event;
 
-class EntityNotDirty
+final class EntityNotDirty
 {
 }

--- a/packages/doctrine-orm-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
+++ b/packages/doctrine-orm-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\DoctrineORMBridge\MessageBus\WrapsMessageHandlingInTransaction;
 use Throwable;
 
-class WrapsMessageHandlingInTransactionTest extends TestCase
+final class WrapsMessageHandlingInTransactionTest extends TestCase
 {
     /**
      * @test
@@ -127,6 +127,6 @@ class WrapsMessageHandlingInTransactionTest extends TestCase
     }
 }
 
-class DummyMessage
+final class DummyMessage
 {
 }

--- a/packages/doctrine-orm-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
+++ b/packages/doctrine-orm-bridge/tests/MessageBus/WrapsMessageHandlingInTransactionTest.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\ManagerRegistry;
 use Error;
 use Exception;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SimpleBus\DoctrineORMBridge\MessageBus\WrapsMessageHandlingInTransaction;
 use Throwable;
@@ -118,12 +117,9 @@ final class WrapsMessageHandlingInTransactionTest extends TestCase
         }
     }
 
-    /**
-     * @return DummyMessage|MockObject
-     */
-    private function dummyMessage()
+    private function dummyMessage(): DummyMessage
     {
-        return $this->createMock(DummyMessage::class);
+        return new DummyMessage();
     }
 }
 

--- a/packages/doctrine-orm-bridge/tests/PHPUnitTestServiceContainer/ServiceProvider/DoctrineOrmServiceProvider.php
+++ b/packages/doctrine-orm-bridge/tests/PHPUnitTestServiceContainer/ServiceProvider/DoctrineOrmServiceProvider.php
@@ -14,7 +14,7 @@ use Pimple\Container;
 use SimpleBus\DoctrineORMBridge\Tests\PHPUnitTestServiceContainer\ServiceContainer;
 use SimpleBus\DoctrineORMBridge\Tests\PHPUnitTestServiceContainer\ServiceProvider;
 
-class DoctrineOrmServiceProvider implements ServiceProvider
+final class DoctrineOrmServiceProvider implements ServiceProvider
 {
     /**
      * @var string[]

--- a/packages/jms-serializer-bridge/src/JMSSerializerObjectSerializer.php
+++ b/packages/jms-serializer-bridge/src/JMSSerializerObjectSerializer.php
@@ -6,7 +6,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use SimpleBus\Serialization\ObjectSerializer;
 
-class JMSSerializerObjectSerializer implements ObjectSerializer
+final class JMSSerializerObjectSerializer implements ObjectSerializer
 {
     private SerializerInterface $serializer;
 

--- a/packages/jms-serializer-bridge/tests/Integration/JMSSerializerObjectSerializerTest.php
+++ b/packages/jms-serializer-bridge/tests/Integration/JMSSerializerObjectSerializerTest.php
@@ -8,7 +8,7 @@ use SimpleBus\JMSSerializerBridge\JMSSerializerObjectSerializer;
 use SimpleBus\JMSSerializerBridge\SerializerMetadata;
 use SimpleBus\Serialization\Envelope\DefaultEnvelope;
 
-class JMSSerializerObjectSerializerTest extends TestCase
+final class JMSSerializerObjectSerializerTest extends TestCase
 {
     /**
      * @test

--- a/packages/jms-serializer-bridge/tests/Integration/SampleMessage.php
+++ b/packages/jms-serializer-bridge/tests/Integration/SampleMessage.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\JMSSerializerBridge\Tests\Integration;
 
-class SampleMessage
+final class SampleMessage
 {
 }

--- a/packages/jms-serializer-bundle-bridge/src/DependencyInjection/SimpleBusJMSSerializerBundleBridgeExtension.php
+++ b/packages/jms-serializer-bundle-bridge/src/DependencyInjection/SimpleBusJMSSerializerBundleBridgeExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class SimpleBusJMSSerializerBundleBridgeExtension extends Extension implements PrependExtensionInterface
+final class SimpleBusJMSSerializerBundleBridgeExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * @param mixed[] $config

--- a/packages/jms-serializer-bundle-bridge/src/SimpleBusJMSSerializerBundleBridgeBundle.php
+++ b/packages/jms-serializer-bundle-bridge/src/SimpleBusJMSSerializerBundleBridgeBundle.php
@@ -5,7 +5,7 @@ namespace SimpleBus\JMSSerializerBundleBridge;
 use SimpleBus\JMSSerializerBundleBridge\DependencyInjection\SimpleBusJMSSerializerBundleBridgeExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SimpleBusJMSSerializerBundleBridgeBundle extends Bundle
+final class SimpleBusJMSSerializerBundleBridgeBundle extends Bundle
 {
     public function getContainerExtension(): SimpleBusJMSSerializerBundleBridgeExtension
     {

--- a/packages/jms-serializer-bundle-bridge/tests/Functional/JMSSerializerMessageSerializerTest.php
+++ b/packages/jms-serializer-bundle-bridge/tests/Functional/JMSSerializerMessageSerializerTest.php
@@ -5,7 +5,7 @@ namespace SimpleBus\JMSSerializerBundleBridge\Tests\Functional;
 use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopeSerializer;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class JMSSerializerMessageSerializerTest extends KernelTestCase
+final class JMSSerializerMessageSerializerTest extends KernelTestCase
 {
     protected function tearDown(): void
     {

--- a/packages/jms-serializer-bundle-bridge/tests/Functional/SampleMessage.php
+++ b/packages/jms-serializer-bundle-bridge/tests/Functional/SampleMessage.php
@@ -4,7 +4,7 @@ namespace SimpleBus\JMSSerializerBundleBridge\Tests\Functional;
 
 use JMS\Serializer\Annotation as Serializer;
 
-class SampleMessage
+final class SampleMessage
 {
     /**
      * @Serializer\Type("string")

--- a/packages/jms-serializer-bundle-bridge/tests/Functional/TestKernel.php
+++ b/packages/jms-serializer-bundle-bridge/tests/Functional/TestKernel.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-class TestKernel extends Kernel
+final class TestKernel extends Kernel
 {
     private string $tempDir = __DIR__.'/temp';
 

--- a/packages/message-bus/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
+++ b/packages/message-bus/src/Bus/Middleware/FinishesHandlingMessageBeforeHandlingNext.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Bus\Middleware;
 
 use Throwable;
 
-class FinishesHandlingMessageBeforeHandlingNext implements MessageBusMiddleware
+final class FinishesHandlingMessageBeforeHandlingNext implements MessageBusMiddleware
 {
     /**
      * @var object[]

--- a/packages/message-bus/src/CallableResolver/Exception/CouldNotResolveCallable.php
+++ b/packages/message-bus/src/CallableResolver/Exception/CouldNotResolveCallable.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\CallableResolver\Exception;
 
 use LogicException;
 
-class CouldNotResolveCallable extends LogicException
+final class CouldNotResolveCallable extends LogicException
 {
     /**
      * @param mixed $value

--- a/packages/message-bus/src/CallableResolver/Exception/UndefinedCallable.php
+++ b/packages/message-bus/src/CallableResolver/Exception/UndefinedCallable.php
@@ -4,6 +4,6 @@ namespace SimpleBus\Message\CallableResolver\Exception;
 
 use LogicException;
 
-class UndefinedCallable extends LogicException
+final class UndefinedCallable extends LogicException
 {
 }

--- a/packages/message-bus/src/CallableResolver/ServiceLocatorAwareCallableResolver.php
+++ b/packages/message-bus/src/CallableResolver/ServiceLocatorAwareCallableResolver.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\CallableResolver;
 
 use SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable;
 
-class ServiceLocatorAwareCallableResolver implements CallableResolver
+final class ServiceLocatorAwareCallableResolver implements CallableResolver
 {
     /**
      * @var callable

--- a/packages/message-bus/src/Handler/DelegatesToMessageHandlerMiddleware.php
+++ b/packages/message-bus/src/Handler/DelegatesToMessageHandlerMiddleware.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Message\Handler;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\Handler\Resolver\MessageHandlerResolver;
 
-class DelegatesToMessageHandlerMiddleware implements MessageBusMiddleware
+final class DelegatesToMessageHandlerMiddleware implements MessageBusMiddleware
 {
     private MessageHandlerResolver $messageHandlerResolver;
 

--- a/packages/message-bus/src/Handler/Resolver/NameBasedMessageHandlerResolver.php
+++ b/packages/message-bus/src/Handler/Resolver/NameBasedMessageHandlerResolver.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Message\Handler\Resolver;
 use SimpleBus\Message\CallableResolver\CallableMap;
 use SimpleBus\Message\Name\MessageNameResolver;
 
-class NameBasedMessageHandlerResolver implements MessageHandlerResolver
+final class NameBasedMessageHandlerResolver implements MessageHandlerResolver
 {
     private MessageNameResolver $messageNameResolver;
 

--- a/packages/message-bus/src/Logging/LoggingMiddleware.php
+++ b/packages/message-bus/src/Logging/LoggingMiddleware.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Message\Logging;
 use Psr\Log\LoggerInterface;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 
-class LoggingMiddleware implements MessageBusMiddleware
+final class LoggingMiddleware implements MessageBusMiddleware
 {
     private LoggerInterface $logger;
 

--- a/packages/message-bus/src/Name/ClassBasedNameResolver.php
+++ b/packages/message-bus/src/Name/ClassBasedNameResolver.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Name;
 
-class ClassBasedNameResolver implements MessageNameResolver
+final class ClassBasedNameResolver implements MessageNameResolver
 {
     /**
      * The unique name of a message is assumed to be its fully qualified class name.

--- a/packages/message-bus/src/Name/Exception/CouldNotResolveMessageName.php
+++ b/packages/message-bus/src/Name/Exception/CouldNotResolveMessageName.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Name\Exception;
 
 use LogicException;
 
-class CouldNotResolveMessageName extends LogicException
+final class CouldNotResolveMessageName extends LogicException
 {
     public static function forMessage(object $message, string $exceptionMessage): self
     {

--- a/packages/message-bus/src/Name/NamedMessageNameResolver.php
+++ b/packages/message-bus/src/Name/NamedMessageNameResolver.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Name;
 
 use SimpleBus\Message\Name\Exception\CouldNotResolveMessageName;
 
-class NamedMessageNameResolver implements MessageNameResolver
+final class NamedMessageNameResolver implements MessageNameResolver
 {
     public function resolve(object $message): string
     {

--- a/packages/message-bus/src/Recorder/AggregatesRecordedMessages.php
+++ b/packages/message-bus/src/Recorder/AggregatesRecordedMessages.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Recorder;
 
-class AggregatesRecordedMessages implements ContainsRecordedMessages
+final class AggregatesRecordedMessages implements ContainsRecordedMessages
 {
     /**
      * @var ContainsRecordedMessages[]

--- a/packages/message-bus/src/Recorder/HandlesRecordedMessagesMiddleware.php
+++ b/packages/message-bus/src/Recorder/HandlesRecordedMessagesMiddleware.php
@@ -6,7 +6,7 @@ use Exception;
 use SimpleBus\Message\Bus\MessageBus;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 
-class HandlesRecordedMessagesMiddleware implements MessageBusMiddleware
+final class HandlesRecordedMessagesMiddleware implements MessageBusMiddleware
 {
     private ContainsRecordedMessages $messageRecorder;
 

--- a/packages/message-bus/src/Recorder/PublicMessageRecorder.php
+++ b/packages/message-bus/src/Recorder/PublicMessageRecorder.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Recorder;
 
-class PublicMessageRecorder implements RecordsMessages
+final class PublicMessageRecorder implements RecordsMessages
 {
     use PrivateMessageRecorderCapabilities { record as public; }
 }

--- a/packages/message-bus/src/Subscriber/NotifiesMessageSubscribersMiddleware.php
+++ b/packages/message-bus/src/Subscriber/NotifiesMessageSubscribersMiddleware.php
@@ -8,7 +8,7 @@ use Psr\Log\NullLogger;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\Subscriber\Resolver\MessageSubscribersResolver;
 
-class NotifiesMessageSubscribersMiddleware implements MessageBusMiddleware
+final class NotifiesMessageSubscribersMiddleware implements MessageBusMiddleware
 {
     private MessageSubscribersResolver $messageSubscribersResolver;
 

--- a/packages/message-bus/src/Subscriber/Resolver/NameBasedMessageSubscriberResolver.php
+++ b/packages/message-bus/src/Subscriber/Resolver/NameBasedMessageSubscriberResolver.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Message\Subscriber\Resolver;
 use SimpleBus\Message\CallableResolver\CallableCollection;
 use SimpleBus\Message\Name\MessageNameResolver;
 
-class NameBasedMessageSubscriberResolver implements MessageSubscribersResolver
+final class NameBasedMessageSubscriberResolver implements MessageSubscribersResolver
 {
     private MessageNameResolver $messageNameResolver;
 

--- a/packages/message-bus/tests/Bus/FinishesCommandBeforeHandlingNextTest.php
+++ b/packages/message-bus/tests/Bus/FinishesCommandBeforeHandlingNextTest.php
@@ -10,7 +10,7 @@ use stdClass;
 use Throwable;
 use TypeError;
 
-class FinishesMessageBeforeHandlingNextTest extends TestCase
+final class FinishesMessageBeforeHandlingNextTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Bus/Fixtures/StubMessageBusMiddleware.php
+++ b/packages/message-bus/tests/Bus/Fixtures/StubMessageBusMiddleware.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Tests\Bus\Fixtures;
 
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 
-class StubMessageBusMiddleware implements MessageBusMiddleware
+final class StubMessageBusMiddleware implements MessageBusMiddleware
 {
     /**
      * @var callable

--- a/packages/message-bus/tests/Bus/MessageBusSupportingMiddlewareTest.php
+++ b/packages/message-bus/tests/Bus/MessageBusSupportingMiddlewareTest.php
@@ -9,7 +9,7 @@ use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
 use stdClass;
 
-class MessageBusSupportingMiddlewareTest extends TestCase
+final class MessageBusSupportingMiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/CallableResolver/CallableCollectionTest.php
+++ b/packages/message-bus/tests/CallableResolver/CallableCollectionTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Message\CallableResolver\CallableCollection;
 use SimpleBus\Message\CallableResolver\CallableResolver;
 
-class CallableCollectionTest extends TestCase
+final class CallableCollectionTest extends TestCase
 {
     /**
      * @var CallableResolver|MockObject

--- a/packages/message-bus/tests/CallableResolver/CallableMapTest.php
+++ b/packages/message-bus/tests/CallableResolver/CallableMapTest.php
@@ -8,7 +8,7 @@ use SimpleBus\Message\CallableResolver\CallableMap;
 use SimpleBus\Message\CallableResolver\CallableResolver;
 use SimpleBus\Message\CallableResolver\Exception\UndefinedCallable;
 
-class CallableMapTest extends TestCase
+final class CallableMapTest extends TestCase
 {
     /**
      * @var CallableResolver|MockObject

--- a/packages/message-bus/tests/CallableResolver/Fixtures/LegacyHandler.php
+++ b/packages/message-bus/tests/CallableResolver/Fixtures/LegacyHandler.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Tests\CallableResolver\Fixtures;
 
-class LegacyHandler
+final class LegacyHandler
 {
     public function handle(object $message): void
     {

--- a/packages/message-bus/tests/CallableResolver/Fixtures/LegacySubscriber.php
+++ b/packages/message-bus/tests/CallableResolver/Fixtures/LegacySubscriber.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Tests\CallableResolver\Fixtures;
 
-class LegacySubscriber
+final class LegacySubscriber
 {
     public function notify(object $message): void
     {

--- a/packages/message-bus/tests/CallableResolver/Fixtures/SubscriberWithCustomNotify.php
+++ b/packages/message-bus/tests/CallableResolver/Fixtures/SubscriberWithCustomNotify.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Tests\CallableResolver\Fixtures;
 
-class SubscriberWithCustomNotify
+final class SubscriberWithCustomNotify
 {
     public function customNotifyMethod(object $message): void
     {

--- a/packages/message-bus/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
+++ b/packages/message-bus/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
@@ -11,7 +11,7 @@ use SimpleBus\Message\Tests\CallableResolver\Fixtures\LegacySubscriber;
 use SimpleBus\Message\Tests\CallableResolver\Fixtures\SubscriberWithCustomNotify;
 use stdClass;
 
-class ServiceLocatorAwareCallableResolverTest extends TestCase
+final class ServiceLocatorAwareCallableResolverTest extends TestCase
 {
     private ServiceLocatorAwareCallableResolver $resolver;
 

--- a/packages/message-bus/tests/Fixtures/CallableSpy.php
+++ b/packages/message-bus/tests/Fixtures/CallableSpy.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Message\Tests\Fixtures;
 
-class CallableSpy
+final class CallableSpy
 {
     private int $hasBeenCalled = 0;
 

--- a/packages/message-bus/tests/Handler/DelegatesToMessageHandlerMiddlewareTest.php
+++ b/packages/message-bus/tests/Handler/DelegatesToMessageHandlerMiddlewareTest.php
@@ -9,7 +9,7 @@ use SimpleBus\Message\Handler\Resolver\MessageHandlerResolver;
 use SimpleBus\Message\Tests\Fixtures\CallableSpy;
 use stdClass;
 
-class DelegatesToMessageHandlerMiddlewareTest extends TestCase
+final class DelegatesToMessageHandlerMiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Handler/Resolver/Fixtures/DummyMessage.php
+++ b/packages/message-bus/tests/Handler/Resolver/Fixtures/DummyMessage.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\Message\Tests\Handler\Resolver\Fixtures;
 
-class DummyMessage
+final class DummyMessage
 {
 }

--- a/packages/message-bus/tests/Handler/Resolver/NameBasedCommandHandlerResolverTest.php
+++ b/packages/message-bus/tests/Handler/Resolver/NameBasedCommandHandlerResolverTest.php
@@ -10,7 +10,7 @@ use SimpleBus\Message\Handler\Resolver\NameBasedMessageHandlerResolver;
 use SimpleBus\Message\Name\MessageNameResolver;
 use stdClass;
 
-class NameBasedMessageHandlerResolverTest extends TestCase
+final class NameBasedMessageHandlerResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Logging/LoggingMiddlewareTest.php
+++ b/packages/message-bus/tests/Logging/LoggingMiddlewareTest.php
@@ -8,7 +8,7 @@ use Psr\Log\LogLevel;
 use SimpleBus\Message\Logging\LoggingMiddleware;
 use stdClass;
 
-class LoggingMiddlewareTest extends TestCase
+final class LoggingMiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Name/ClassBasedNameResolverTest.php
+++ b/packages/message-bus/tests/Name/ClassBasedNameResolverTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Message\Name\ClassBasedNameResolver;
 use SimpleBus\Message\Tests\Handler\Resolver\Fixtures\DummyMessage;
 
-class ClassBasedNameResolverTest extends TestCase
+final class ClassBasedNameResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Name/Fixtures/StubNamedMessage.php
+++ b/packages/message-bus/tests/Name/Fixtures/StubNamedMessage.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Tests\Name\Fixtures;
 
 use SimpleBus\Message\Name\NamedMessage;
 
-class StubNamedMessage implements NamedMessage
+final class StubNamedMessage implements NamedMessage
 {
     public static string $name;
 

--- a/packages/message-bus/tests/Name/NamedMessageNameResolverTest.php
+++ b/packages/message-bus/tests/Name/NamedMessageNameResolverTest.php
@@ -8,7 +8,7 @@ use SimpleBus\Message\Name\NamedMessageNameResolver;
 use SimpleBus\Message\Tests\Name\Fixtures\StubNamedMessage;
 use stdClass;
 
-class NamedMessageNameResolverTest extends TestCase
+final class NamedMessageNameResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Recorder/AggregatesRecordedMessagesTest.php
+++ b/packages/message-bus/tests/Recorder/AggregatesRecordedMessagesTest.php
@@ -7,7 +7,7 @@ use SimpleBus\Message\Recorder\AggregatesRecordedMessages;
 use SimpleBus\Message\Tests\Recorder\Fixtures\ContainsRecordedMessagesStub;
 use stdClass;
 
-class AggregatesRecordedMessagesTest extends TestCase
+final class AggregatesRecordedMessagesTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Recorder/Fixtures/ContainsRecordedMessagesStub.php
+++ b/packages/message-bus/tests/Recorder/Fixtures/ContainsRecordedMessagesStub.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Message\Tests\Recorder\Fixtures;
 
 use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 
-class ContainsRecordedMessagesStub implements ContainsRecordedMessages
+final class ContainsRecordedMessagesStub implements ContainsRecordedMessages
 {
     /**
      * @var object[]

--- a/packages/message-bus/tests/Recorder/Fixtures/PrivateMessageRecorderCapabilitiesStub.php
+++ b/packages/message-bus/tests/Recorder/Fixtures/PrivateMessageRecorderCapabilitiesStub.php
@@ -5,7 +5,7 @@ namespace SimpleBus\Message\Tests\Recorder\Fixtures;
 use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 use SimpleBus\Message\Recorder\PrivateMessageRecorderCapabilities;
 
-class PrivateMessageRecorderCapabilitiesStub implements ContainsRecordedMessages
+final class PrivateMessageRecorderCapabilitiesStub implements ContainsRecordedMessages
 {
     use PrivateMessageRecorderCapabilities;
 

--- a/packages/message-bus/tests/Recorder/HandlesRecordedMessagesMiddlewareTest.php
+++ b/packages/message-bus/tests/Recorder/HandlesRecordedMessagesMiddlewareTest.php
@@ -11,7 +11,7 @@ use SimpleBus\Message\Recorder\HandlesRecordedMessagesMiddleware;
 use SimpleBus\Message\Tests\Fixtures\CallableSpy;
 use stdClass;
 
-class HandlesRecordedMessagesMiddlewareTest extends TestCase
+final class HandlesRecordedMessagesMiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Recorder/MessageRecorderCapabilitiesTest.php
+++ b/packages/message-bus/tests/Recorder/MessageRecorderCapabilitiesTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Message\Tests\Recorder\Fixtures\PrivateMessageRecorderCapabilitiesStub;
 use stdClass;
 
-class MessageRecorderCapabilitiesStubTest extends TestCase
+final class MessageRecorderCapabilitiesStubTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Recorder/PublicMessageRecorderTest.php
+++ b/packages/message-bus/tests/Recorder/PublicMessageRecorderTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Message\Recorder\PublicMessageRecorder;
 use stdClass;
 
-class PublicMessageRecorderTest extends TestCase
+final class PublicMessageRecorderTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Subscriber/NotifiesMessageSubscribersMiddlewareTest.php
+++ b/packages/message-bus/tests/Subscriber/NotifiesMessageSubscribersMiddlewareTest.php
@@ -11,7 +11,7 @@ use SimpleBus\Message\Subscriber\Resolver\MessageSubscribersResolver;
 use SimpleBus\Message\Tests\Fixtures\CallableSpy;
 use stdClass;
 
-class NotifiesMessageSubscribersMiddlewareTest extends TestCase
+final class NotifiesMessageSubscribersMiddlewareTest extends TestCase
 {
     /**
      * @test

--- a/packages/message-bus/tests/Subscriber/Resolver/NameBasedMessageSubscriberResolverTest.php
+++ b/packages/message-bus/tests/Subscriber/Resolver/NameBasedMessageSubscriberResolverTest.php
@@ -9,7 +9,7 @@ use SimpleBus\Message\Name\MessageNameResolver;
 use SimpleBus\Message\Subscriber\Resolver\NameBasedMessageSubscriberResolver;
 use stdClass;
 
-class NameBasedMessageSubscriberResolverTest extends TestCase
+final class NameBasedMessageSubscriberResolverTest extends TestCase
 {
     /**
      * @test

--- a/packages/rabbitmq-bundle-bridge/src/DependencyInjection/Compiler/AdditionalPropertiesResolverPass.php
+++ b/packages/rabbitmq-bundle-bridge/src/DependencyInjection/Compiler/AdditionalPropertiesResolverPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class AdditionalPropertiesResolverPass implements CompilerPassInterface
+final class AdditionalPropertiesResolverPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/packages/rabbitmq-bundle-bridge/src/DependencyInjection/Configuration.php
+++ b/packages/rabbitmq-bundle-bridge/src/DependencyInjection/Configuration.php
@@ -5,7 +5,7 @@ namespace SimpleBus\RabbitMQBundleBridge\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     private string $alias;
 

--- a/packages/rabbitmq-bundle-bridge/src/DependencyInjection/SimpleBusRabbitMQBundleBridgeExtension.php
+++ b/packages/rabbitmq-bundle-bridge/src/DependencyInjection/SimpleBusRabbitMQBundleBridgeExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class SimpleBusRabbitMQBundleBridgeExtension extends ConfigurableExtension implements PrependExtensionInterface
+final class SimpleBusRabbitMQBundleBridgeExtension extends ConfigurableExtension implements PrependExtensionInterface
 {
     private string $alias;
 

--- a/packages/rabbitmq-bundle-bridge/src/Event/AbstractMessageEvent.php
+++ b/packages/rabbitmq-bundle-bridge/src/Event/AbstractMessageEvent.php
@@ -6,7 +6,7 @@ use BadMethodCallException;
 use PhpAmqpLib\Message\AMQPMessage;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class AbstractMessageEvent extends Event
+abstract class AbstractMessageEvent extends Event
 {
     private AMQPMessage $message;
 

--- a/packages/rabbitmq-bundle-bridge/src/Event/MessageConsumed.php
+++ b/packages/rabbitmq-bundle-bridge/src/Event/MessageConsumed.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\RabbitMQBundleBridge\Event;
 
-class MessageConsumed extends AbstractMessageEvent
+final class MessageConsumed extends AbstractMessageEvent
 {
 }

--- a/packages/rabbitmq-bundle-bridge/src/Event/MessageConsumptionFailed.php
+++ b/packages/rabbitmq-bundle-bridge/src/Event/MessageConsumptionFailed.php
@@ -5,7 +5,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Event;
 use Exception;
 use PhpAmqpLib\Message\AMQPMessage;
 
-class MessageConsumptionFailed extends AbstractMessageEvent
+final class MessageConsumptionFailed extends AbstractMessageEvent
 {
     private Exception $exception;
 

--- a/packages/rabbitmq-bundle-bridge/src/EventListener/LogErrorWhenMessageConsumptionFailed.php
+++ b/packages/rabbitmq-bundle-bridge/src/EventListener/LogErrorWhenMessageConsumptionFailed.php
@@ -7,7 +7,7 @@ use SimpleBus\RabbitMQBundleBridge\Event\Events;
 use SimpleBus\RabbitMQBundleBridge\Event\MessageConsumptionFailed;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LogErrorWhenMessageConsumptionFailed implements EventSubscriberInterface
+final class LogErrorWhenMessageConsumptionFailed implements EventSubscriberInterface
 {
     private LoggerInterface $logger;
 

--- a/packages/rabbitmq-bundle-bridge/src/RabbitMQMessageConsumer.php
+++ b/packages/rabbitmq-bundle-bridge/src/RabbitMQMessageConsumer.php
@@ -11,7 +11,7 @@ use SimpleBus\RabbitMQBundleBridge\Event\MessageConsumed;
 use SimpleBus\RabbitMQBundleBridge\Event\MessageConsumptionFailed;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class RabbitMQMessageConsumer implements ConsumerInterface
+final class RabbitMQMessageConsumer implements ConsumerInterface
 {
     private SerializedEnvelopeConsumer $consumer;
 

--- a/packages/rabbitmq-bundle-bridge/src/RabbitMQPublisher.php
+++ b/packages/rabbitmq-bundle-bridge/src/RabbitMQPublisher.php
@@ -10,7 +10,7 @@ use SimpleBus\Asynchronous\Publisher\Publisher;
 use SimpleBus\Asynchronous\Routing\RoutingKeyResolver;
 use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopeSerializer;
 
-class RabbitMQPublisher implements Publisher
+final class RabbitMQPublisher implements Publisher
 {
     private MessageInEnvelopeSerializer $serializer;
 

--- a/packages/rabbitmq-bundle-bridge/src/SimpleBusRabbitMQBundleBridgeBundle.php
+++ b/packages/rabbitmq-bundle-bridge/src/SimpleBusRabbitMQBundleBridgeBundle.php
@@ -7,7 +7,7 @@ use SimpleBus\RabbitMQBundleBridge\DependencyInjection\SimpleBusRabbitMQBundleBr
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SimpleBusRabbitMQBundleBridgeBundle extends Bundle
+final class SimpleBusRabbitMQBundleBridgeBundle extends Bundle
 {
     public function getContainerExtension(): SimpleBusRabbitMQBundleBridgeExtension
     {

--- a/packages/rabbitmq-bundle-bridge/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
+++ b/packages/rabbitmq-bundle-bridge/tests/DependencyInjection/Compiler/AdditionalPropertiesResolverPassTest.php
@@ -7,7 +7,7 @@ use SimpleBus\RabbitMQBundleBridge\DependencyInjection\Compiler\AdditionalProper
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class AdditionalPropertiesResolverPassTest extends TestCase
+final class AdditionalPropertiesResolverPassTest extends TestCase
 {
     private ContainerBuilder $container;
 
@@ -72,14 +72,14 @@ class AdditionalPropertiesResolverPassTest extends TestCase
     }
 }
 
-class Resolver1
+final class Resolver1
 {
 }
 
-class Resolver2
+final class Resolver2
 {
 }
 
-class Resolver3
+final class Resolver3
 {
 }

--- a/packages/rabbitmq-bundle-bridge/tests/EventListener/LogErrorWhenMessageConsumptionFailedTest.php
+++ b/packages/rabbitmq-bundle-bridge/tests/EventListener/LogErrorWhenMessageConsumptionFailedTest.php
@@ -11,7 +11,7 @@ use Psr\Log\LogLevel;
 use SimpleBus\RabbitMQBundleBridge\Event\MessageConsumptionFailed;
 use SimpleBus\RabbitMQBundleBridge\EventListener\LogErrorWhenMessageConsumptionFailed;
 
-class LogErrorWhenMessageConsumptionFailedTest extends TestCase
+final class LogErrorWhenMessageConsumptionFailedTest extends TestCase
 {
     /**
      * @test

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/AdditionalPropertiesResolverArray.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/AdditionalPropertiesResolverArray.php
@@ -4,7 +4,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
 use SimpleBus\Asynchronous\Properties\AdditionalPropertiesResolver;
 
-class AdditionalPropertiesResolverArray implements AdditionalPropertiesResolver
+final class AdditionalPropertiesResolverArray implements AdditionalPropertiesResolver
 {
     /**
      * @var array<string, string>

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/AdditionalPropertiesResolverProducerMock.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/AdditionalPropertiesResolverProducerMock.php
@@ -4,7 +4,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
 
-class AdditionalPropertiesResolverProducerMock extends Producer
+final class AdditionalPropertiesResolverProducerMock extends Producer
 {
     /**
      * @var mixed[]

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/AlwaysFailingCommand.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/AlwaysFailingCommand.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
-class AlwaysFailingCommand
+final class AlwaysFailingCommand
 {
 }

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/AlwaysFailingCommandHandler.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/AlwaysFailingCommandHandler.php
@@ -4,7 +4,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
 use Exception;
 
-class AlwaysFailingCommandHandler
+final class AlwaysFailingCommandHandler
 {
     public function handle(): void
     {

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/AsynchronousCommand.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/AsynchronousCommand.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
-class AsynchronousCommand
+final class AsynchronousCommand
 {
 }

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/Event.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/Event.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
-class Event
+final class Event
 {
 }

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/FileLogger.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/FileLogger.php
@@ -5,7 +5,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 use Psr\Log\AbstractLogger;
 use RuntimeException;
 
-class FileLogger extends AbstractLogger
+final class FileLogger extends AbstractLogger
 {
     private string $path;
 

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/LoggingCommandHandler.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/LoggingCommandHandler.php
@@ -4,7 +4,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
 use Psr\Log\LoggerInterface;
 
-class LoggingCommandHandler
+final class LoggingCommandHandler
 {
     private LoggerInterface $logger;
 

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/LoggingEventSubscriber.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/LoggingEventSubscriber.php
@@ -4,7 +4,7 @@ namespace SimpleBus\RabbitMQBundleBridge\Tests\Functional;
 
 use Psr\Log\LoggerInterface;
 
-class LoggingEventSubscriber
+final class LoggingEventSubscriber
 {
     private LoggerInterface $logger;
 

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/SimpleBusRabbitMQBundleTest.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/SimpleBusRabbitMQBundleTest.php
@@ -9,7 +9,7 @@ use stdClass;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Process\Process;
 
-class SimpleBusRabbitMQBundleTest extends KernelTestCase
+final class SimpleBusRabbitMQBundleTest extends KernelTestCase
 {
     private FileLogger $logger;
 

--- a/packages/rabbitmq-bundle-bridge/tests/Functional/TestKernel.php
+++ b/packages/rabbitmq-bundle-bridge/tests/Functional/TestKernel.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-class TestKernel extends Kernel
+final class TestKernel extends Kernel
 {
     private string $tempDir;
 

--- a/packages/rabbitmq-bundle-bridge/tests/RabbitMQMessageConsumerTest.php
+++ b/packages/rabbitmq-bundle-bridge/tests/RabbitMQMessageConsumerTest.php
@@ -14,7 +14,7 @@ use SimpleBus\RabbitMQBundleBridge\Event\MessageConsumptionFailed;
 use SimpleBus\RabbitMQBundleBridge\RabbitMQMessageConsumer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class RabbitMQMessageConsumerTest extends TestCase
+final class RabbitMQMessageConsumerTest extends TestCase
 {
     /**
      * @test

--- a/packages/rabbitmq-bundle-bridge/tests/RabbitMQPublisherTest.php
+++ b/packages/rabbitmq-bundle-bridge/tests/RabbitMQPublisherTest.php
@@ -11,7 +11,7 @@ use SimpleBus\RabbitMQBundleBridge\RabbitMQPublisher;
 use SimpleBus\Serialization\Envelope\Serializer\MessageInEnvelopeSerializer;
 use stdClass;
 
-class RabbitMQPublisherTest extends TestCase
+final class RabbitMQPublisherTest extends TestCase
 {
     /**
      * @test

--- a/packages/serialization/src/Envelope/DefaultEnvelope.php
+++ b/packages/serialization/src/Envelope/DefaultEnvelope.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Serialization\Envelope;
 
 use LogicException;
 
-class DefaultEnvelope implements Envelope
+final class DefaultEnvelope implements Envelope
 {
     /**
      * @var class-string
@@ -18,7 +18,7 @@ class DefaultEnvelope implements Envelope
     /**
      * @param class-string $messageType
      */
-    protected function __construct(string $messageType, ?object $message, ?string $serializedMessage)
+    private function __construct(string $messageType, ?object $message, ?string $serializedMessage)
     {
         $this->messageType = $messageType;
         $this->message = $message;

--- a/packages/serialization/src/Envelope/DefaultEnvelopeFactory.php
+++ b/packages/serialization/src/Envelope/DefaultEnvelopeFactory.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Serialization\Envelope;
 
-class DefaultEnvelopeFactory implements EnvelopeFactory
+final class DefaultEnvelopeFactory implements EnvelopeFactory
 {
     public function wrapMessageInEnvelope(object $message): Envelope
     {

--- a/packages/serialization/src/Envelope/Serializer/StandardMessageInEnvelopeSerializer.php
+++ b/packages/serialization/src/Envelope/Serializer/StandardMessageInEnvelopeSerializer.php
@@ -7,7 +7,7 @@ use SimpleBus\Serialization\Envelope\Envelope;
 use SimpleBus\Serialization\Envelope\EnvelopeFactory;
 use SimpleBus\Serialization\ObjectSerializer;
 
-class StandardMessageInEnvelopeSerializer implements MessageInEnvelopeSerializer
+final class StandardMessageInEnvelopeSerializer implements MessageInEnvelopeSerializer
 {
     private EnvelopeFactory $envelopeFactory;
 

--- a/packages/serialization/src/NativeObjectSerializer.php
+++ b/packages/serialization/src/NativeObjectSerializer.php
@@ -4,7 +4,7 @@ namespace SimpleBus\Serialization;
 
 use LogicException;
 
-class NativeObjectSerializer implements ObjectSerializer
+final class NativeObjectSerializer implements ObjectSerializer
 {
     /**
      * Serialize the given object using the native `serialize()` function.

--- a/packages/serialization/tests/Envelope/DefaultEnvelopeFactoryTest.php
+++ b/packages/serialization/tests/Envelope/DefaultEnvelopeFactoryTest.php
@@ -7,7 +7,7 @@ use SimpleBus\Serialization\Envelope\DefaultEnvelope;
 use SimpleBus\Serialization\Envelope\DefaultEnvelopeFactory;
 use SimpleBus\Serialization\Tests\Fixtures\DummyMessage;
 
-class DefaultEnvelopeFactoryTest extends TestCase
+final class DefaultEnvelopeFactoryTest extends TestCase
 {
     /**
      * @test

--- a/packages/serialization/tests/Envelope/DefaultEnvelopeTest.php
+++ b/packages/serialization/tests/Envelope/DefaultEnvelopeTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleBus\Serialization\Envelope\DefaultEnvelope;
 use SimpleBus\Serialization\Tests\Fixtures\DummyMessage;
 
-class DefaultEnvelopeTest extends TestCase
+final class DefaultEnvelopeTest extends TestCase
 {
     /**
      * @test

--- a/packages/serialization/tests/Envelope/Serializer/StandardMessageInEnvelopeSerializerTest.php
+++ b/packages/serialization/tests/Envelope/Serializer/StandardMessageInEnvelopeSerializerTest.php
@@ -13,7 +13,7 @@ use SimpleBus\Serialization\ObjectSerializer;
 use SimpleBus\Serialization\Tests\Fixtures\DummyMessage;
 use stdClass;
 
-class StandardMessageInEnvelopeSerializerTest extends TestCase
+final class StandardMessageInEnvelopeSerializerTest extends TestCase
 {
     /**
      * @test

--- a/packages/serialization/tests/Fixtures/AnotherDummyMessage.php
+++ b/packages/serialization/tests/Fixtures/AnotherDummyMessage.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\Serialization\Tests\Fixtures;
 
-class AnotherDummyMessage
+final class AnotherDummyMessage
 {
 }

--- a/packages/serialization/tests/Fixtures/DummyMessage.php
+++ b/packages/serialization/tests/Fixtures/DummyMessage.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\Serialization\Tests\Fixtures;
 
-class DummyMessage
+final class DummyMessage
 {
     public string $foo;
 }

--- a/packages/serialization/tests/NativeObjectSerializerTest.php
+++ b/packages/serialization/tests/NativeObjectSerializerTest.php
@@ -9,7 +9,7 @@ use SimpleBus\Serialization\NativeObjectSerializer;
 use SimpleBus\Serialization\Tests\Fixtures\AnotherDummyMessage;
 use SimpleBus\Serialization\Tests\Fixtures\DummyMessage;
 
-class NativeObjectSerializerTest extends TestCase
+final class NativeObjectSerializerTest extends TestCase
 {
     /**
      * @test

--- a/packages/symfony-bridge/src/DependencyInjection/CommandBusConfiguration.php
+++ b/packages/symfony-bridge/src/DependencyInjection/CommandBusConfiguration.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class CommandBusConfiguration implements ConfigurationInterface
+final class CommandBusConfiguration implements ConfigurationInterface
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DependencyInjection/CommandBusExtension.php
+++ b/packages/symfony-bridge/src/DependencyInjection/CommandBusExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class CommandBusExtension extends ConfigurableExtension
+final class CommandBusExtension extends ConfigurableExtension
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DependencyInjection/Compiler/AddMiddlewareTags.php
+++ b/packages/symfony-bridge/src/DependencyInjection/Compiler/AddMiddlewareTags.php
@@ -6,7 +6,7 @@ use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class AddMiddlewareTags implements CompilerPassInterface
+final class AddMiddlewareTags implements CompilerPassInterface
 {
     private const MESSAGE_BUS_TAG = 'message_bus';
 

--- a/packages/symfony-bridge/src/DependencyInjection/Compiler/ConfigureMiddlewares.php
+++ b/packages/symfony-bridge/src/DependencyInjection/Compiler/ConfigureMiddlewares.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigureMiddlewares implements CompilerPassInterface
+final class ConfigureMiddlewares implements CompilerPassInterface
 {
     private string $mainBusId;
     private string $busTag;

--- a/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterHandlers.php
+++ b/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterHandlers.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class RegisterHandlers implements CompilerPassInterface
+final class RegisterHandlers implements CompilerPassInterface
 {
     use CollectServices;
 

--- a/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterMessageRecorders.php
+++ b/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterMessageRecorders.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class RegisterMessageRecorders implements CompilerPassInterface
+final class RegisterMessageRecorders implements CompilerPassInterface
 {
     private string $aggregatorId;
     private string $recorderTag;

--- a/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterSubscribers.php
+++ b/packages/symfony-bridge/src/DependencyInjection/Compiler/RegisterSubscribers.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class RegisterSubscribers implements CompilerPassInterface
+final class RegisterSubscribers implements CompilerPassInterface
 {
     use CollectServices;
 

--- a/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
+++ b/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeConfiguration.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class DoctrineOrmBridgeConfiguration implements ConfigurationInterface
+final class DoctrineOrmBridgeConfiguration implements ConfigurationInterface
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeExtension.php
+++ b/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class DoctrineOrmBridgeExtension extends ConfigurableExtension
+final class DoctrineOrmBridgeExtension extends ConfigurableExtension
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DependencyInjection/EventBusConfiguration.php
+++ b/packages/symfony-bridge/src/DependencyInjection/EventBusConfiguration.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class EventBusConfiguration implements ConfigurationInterface
+final class EventBusConfiguration implements ConfigurationInterface
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DependencyInjection/EventBusExtension.php
+++ b/packages/symfony-bridge/src/DependencyInjection/EventBusExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
-class EventBusExtension extends ConfigurableExtension
+final class EventBusExtension extends ConfigurableExtension
 {
     private string $alias;
 

--- a/packages/symfony-bridge/src/DoctrineOrmBridgeBundle.php
+++ b/packages/symfony-bridge/src/DoctrineOrmBridgeBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class DoctrineOrmBridgeBundle extends Bundle
+final class DoctrineOrmBridgeBundle extends Bundle
 {
     use RequiresOtherBundles;
 

--- a/packages/symfony-bridge/src/SimpleBusCommandBusBundle.php
+++ b/packages/symfony-bridge/src/SimpleBusCommandBusBundle.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SimpleBusCommandBusBundle extends Bundle
+final class SimpleBusCommandBusBundle extends Bundle
 {
     private string $configurationAlias;
 

--- a/packages/symfony-bridge/src/SimpleBusEventBusBundle.php
+++ b/packages/symfony-bridge/src/SimpleBusEventBusBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SimpleBusEventBusBundle extends Bundle
+final class SimpleBusEventBusBundle extends Bundle
 {
     use RequiresOtherBundles;
 

--- a/packages/symfony-bridge/tests/Functional/DoctrineOrmSmokeTest.php
+++ b/packages/symfony-bridge/tests/Functional/DoctrineOrmSmokeTest.php
@@ -16,7 +16,7 @@ use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestEntityCreatedEventSub
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class DoctrineOrmSmokeTest extends KernelTestCase
+final class DoctrineOrmSmokeTest extends KernelTestCase
 {
     protected function tearDown(): void
     {

--- a/packages/symfony-bridge/tests/Functional/Php8SmokeTest.php
+++ b/packages/symfony-bridge/tests/Functional/Php8SmokeTest.php
@@ -14,7 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  * @coversNothing
  * @requires PHP 8.0
  */
-class Php8SmokeTest extends KernelTestCase
+final class Php8SmokeTest extends KernelTestCase
 {
     protected function tearDown(): void
     {

--- a/packages/symfony-bridge/tests/Functional/SmokeTest.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest.php
@@ -13,7 +13,7 @@ use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEventSubscriberU
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class SmokeTest extends KernelTestCase
+final class SmokeTest extends KernelTestCase
 {
     protected function tearDown(): void
     {

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/DoctrineTestKernel.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/DoctrineTestKernel.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-class DoctrineTestKernel extends Kernel
+final class DoctrineTestKernel extends Kernel
 {
     private string $tempDir;
 

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherEvent.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherEvent.php
@@ -4,7 +4,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
 use SimpleBus\Message\Name\NamedMessage;
 
-class SomeOtherEvent implements NamedMessage
+final class SomeOtherEvent implements NamedMessage
 {
     public static function messageName(): string
     {

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherEventSubscriber.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherEventSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
-class SomeOtherEventSubscriber
+final class SomeOtherEventSubscriber
 {
     public bool $eventHandled = false;
 

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherTestCommand.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherTestCommand.php
@@ -2,7 +2,7 @@
 
 namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
-class SomeOtherTestCommand
+final class SomeOtherTestCommand
 {
     public function name(): string
     {

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherTestCommandHandler.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/SomeOtherTestCommandHandler.php
@@ -4,7 +4,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
 use SimpleBus\Message\Recorder\RecordsMessages;
 
-class SomeOtherTestCommandHandler
+final class SomeOtherTestCommandHandler
 {
     public bool $commandHandled = false;
     private RecordsMessages $messageRecorder;

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/TestCommand.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/TestCommand.php
@@ -2,6 +2,6 @@
 
 namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
-class TestCommand
+final class TestCommand
 {
 }

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/TestCommandHandler.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/TestCommandHandler.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 use Doctrine\ORM\EntityManager;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Entity\TestEntity;
 
-class TestCommandHandler
+final class TestCommandHandler
 {
     public bool $commandHandled = false;
 

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/TestEntityCreated.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/TestEntityCreated.php
@@ -5,7 +5,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 use SimpleBus\Message\Name\NamedMessage;
 use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Entity\TestEntity;
 
-class TestEntityCreated implements NamedMessage
+final class TestEntityCreated implements NamedMessage
 {
     private TestEntity $testEntity;
 

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/TestEntityCreatedEventSubscriber.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/TestEntityCreatedEventSubscriber.php
@@ -4,7 +4,7 @@ namespace SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest;
 
 use SimpleBus\Message\Bus\MessageBus;
 
-class TestEntityCreatedEventSubscriber
+final class TestEntityCreatedEventSubscriber
 {
     public bool $eventHandled = false;
     private MessageBus $commandBus;

--- a/packages/symfony-bridge/tests/Functional/SmokeTest/TestKernel.php
+++ b/packages/symfony-bridge/tests/Functional/SmokeTest/TestKernel.php
@@ -11,7 +11,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
-class TestKernel extends Kernel
+final class TestKernel extends Kernel
 {
     private string $tempDir;
 

--- a/packages/symfony-bridge/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
+++ b/packages/symfony-bridge/tests/SymfonyBundle/DependencyInjection/Compiler/ConfigureMiddlewaresTest.php
@@ -10,7 +10,7 @@ use SimpleBus\SymfonyBridge\Tests\Functional\SmokeTest\Auto\AutoEvent3;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ConfigureMiddlewaresTest extends TestCase
+final class ConfigureMiddlewaresTest extends TestCase
 {
     private ContainerBuilder $container;
 


### PR DESCRIPTION
The idea is to make everything final as almost everything implements an interface already.

Why? https://matthiasnoback.nl/2018/09/final-classes-by-default-why/

I left the following not-final:
```
class AsynchronousCommandBus extends MessageBusSupportingMiddleware
class AsynchronousEventBus extends MessageBusSupportingMiddleware
class MessageBusSupportingMiddleware implements MessageBus
class CallableCollection
class CallableMap
class CommandBus extends MessageBusSupportingMiddleware
class EventBus extends MessageBusSupportingMiddleware
```

This will be released in a new major version together with other refactorings.