### PR TITLE
Loosen the type of the map in CallableCollection

### DIFF
--- a/packages/message-bus/src/CallableResolver/CallableCollection.php
+++ b/packages/message-bus/src/CallableResolver/CallableCollection.php
@@ -5,14 +5,14 @@ namespace SimpleBus\Message\CallableResolver;
 class CallableCollection
 {
     /**
-     * @var array<string, callable[]>
+     * @var array<string, mixed[]>
      */
     private array $callablesByName;
 
     private CallableResolver $callableResolver;
 
     /**
-     * @param array<string, callable[]> $callablesByName
+     * @param array<string, mixed[]> $callablesByName
      */
     public function __construct(
         array $callablesByName,


### PR DESCRIPTION
`CallableResolver` takes `callable|mixed|object|string` (which can be simplified to just `mixed`). If they were callables already, we wouldn't need the resolver.