### PR TITLE
Convert CollectsEventsFromEntities to listener

### DIFF
--- a/packages/doctrine-orm-bridge/src/EventListener/CollectsEventsFromEntities.php
+++ b/packages/doctrine-orm-bridge/src/EventListener/CollectsEventsFromEntities.php
@@ -2,27 +2,18 @@
 
 namespace SimpleBus\DoctrineORMBridge\EventListener;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Proxy\Proxy;
 use SimpleBus\Message\Recorder\ContainsRecordedMessages;
 
-class CollectsEventsFromEntities implements EventSubscriber, ContainsRecordedMessages
+class CollectsEventsFromEntities implements ContainsRecordedMessages
 {
     /**
      * @var object[]
      */
     private array $collectedEvents = [];
-
-    public function getSubscribedEvents(): array
-    {
-        return [
-            Events::preFlush,
-            Events::postFlush,
-        ];
-    }
 
     public function preFlush(PreFlushEventArgs $eventArgs): void
     {

--- a/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeExtension.php
+++ b/packages/symfony-bridge/src/DependencyInjection/DoctrineOrmBridgeExtension.php
@@ -2,6 +2,7 @@
 
 namespace SimpleBus\SymfonyBridge\DependencyInjection;
 
+use Doctrine\ORM\Events;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -46,6 +47,7 @@ class DoctrineOrmBridgeExtension extends ConfigurableExtension
         $connection = $container->getParameterBag()->resolveValue($mergedConfig['connection']);
         $container
             ->findDefinition('simple_bus.doctrine_orm_bridge.collects_events_from_entities')
-            ->addTag('doctrine.event_subscriber', ['connection' => $connection]);
+            ->addTag('doctrine.event_listener', ['connection' => $connection, 'event' => Events::preFlush])
+            ->addTag('doctrine.event_listener', ['connection' => $connection, 'event' => Events::postFlush]);
     }
 }


### PR DESCRIPTION
This fixes the following deprecation in Symfony 6.3:

Since symfony/doctrine-bridge 6.3: Registering "SimpleBus\DoctrineORMBridge\EventListener\CollectsEventsFromEntities" as a Doctrine subscriber is deprecated. Register it as a listener instead, using e.g. the #[AsDoctrineListener] attribute.